### PR TITLE
feat: Add arm64 targets for Apple Silicon 

### DIFF
--- a/.github/workflows/build-koney.yaml
+++ b/.github/workflows/build-koney.yaml
@@ -9,8 +9,8 @@ on:
       - v*
 
 env:
-  CONTROLLER_IMAGE: ghcr.io/floschick/koney-controller
-  ALERT_FORWARDER_IMAGE: ghcr.io/floschick/koney-alert-forwarder
+  CONTROLLER_IMAGE: ghcr.io/dynatrace-oss/koney-controller
+  ALERT_FORWARDER_IMAGE: ghcr.io/dynatrace-oss/koney-alert-forwarder
 
 jobs:
   build-koney-controller:

--- a/.github/workflows/build-koney.yaml
+++ b/.github/workflows/build-koney.yaml
@@ -1,7 +1,6 @@
 name: build-koney
 
 on:
-  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/build-koney.yaml
+++ b/.github/workflows/build-koney.yaml
@@ -10,8 +10,8 @@ on:
       - v*
 
 env:
-  CONTROLLER_IMAGE: ghcr.io/dynatrace-oss/koney-controller
-  ALERT_FORWARDER_IMAGE: ghcr.io/dynatrace-oss/koney-alert-forwarder
+  CONTROLLER_IMAGE: ghcr.io/floschick/koney-controller
+  ALERT_FORWARDER_IMAGE: ghcr.io/floschick/koney-alert-forwarder
 
 jobs:
   build-koney-controller:

--- a/.github/workflows/build-koney.yaml
+++ b/.github/workflows/build-koney.yaml
@@ -1,6 +1,7 @@
 name: build-koney
 
 on:
+  workflow_dispatch:
   pull_request:
   push:
     branches:

--- a/.github/workflows/build-koney.yaml
+++ b/.github/workflows/build-koney.yaml
@@ -90,5 +90,6 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=${{ env.ALERT_FORWARDER_IMAGE }}:buildcache
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}:buildcache,mode=max', env.ALERT_FORWARDER_IMAGE) || '' }}

--- a/.github/workflows/build-koney.yaml
+++ b/.github/workflows/build-koney.yaml
@@ -9,8 +9,8 @@ on:
       - v*
 
 env:
-  CONTROLLER_IMAGE: ghcr.io/dynatrace-oss/koney-controller
-  ALERT_FORWARDER_IMAGE: ghcr.io/dynatrace-oss/koney-alert-forwarder
+  CONTROLLER_IMAGE: ghcr.io/floschick/koney-controller
+  ALERT_FORWARDER_IMAGE: ghcr.io/floschick/koney-alert-forwarder
 
 jobs:
   build-koney-controller:

--- a/.github/workflows/build-koney.yaml
+++ b/.github/workflows/build-koney.yaml
@@ -10,8 +10,8 @@ on:
       - v*
 
 env:
-  CONTROLLER_IMAGE: ghcr.io/floschick/koney-controller
-  ALERT_FORWARDER_IMAGE: ghcr.io/floschick/koney-alert-forwarder
+  CONTROLLER_IMAGE: ghcr.io/dynatrace-oss/koney-controller
+  ALERT_FORWARDER_IMAGE: ghcr.io/dynatrace-oss/koney-alert-forwarder
 
 jobs:
   build-koney-controller:
@@ -51,6 +51,7 @@ jobs:
           push: ${{ github.event_name == 'push' }}
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/amd64,linux/arm64
           cache-from: type=registry,ref=${{ env.CONTROLLER_IMAGE }}:buildcache
           cache-to: ${{ github.event_name == 'push' && format('type=registry,ref={0}:buildcache,mode=max', env.CONTROLLER_IMAGE) || '' }}
 


### PR DESCRIPTION
This PR adds arm64 build targets to the Docker images, enabling native support on Apple Silicon machines.
Resolves: https://github.com/dynatrace-oss/koney/issues/4