### PR TITLE
Put latest tag only when tags are pushed [TR-4419]

### DIFF
--- a/.github/workflows/build-koney.yaml
+++ b/.github/workflows/build-koney.yaml
@@ -25,9 +25,10 @@ jobs:
         with:
           images: |
             ${{ env.CONTROLLER_IMAGE }}
+          flavor: |
+            latest=auto
           tags: |
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}
@@ -66,9 +67,10 @@ jobs:
         with:
           images: |
             ${{ env.ALERT_FORWARDER_IMAGE }}
+          flavor: |
+            latest=auto
           tags: |
             type=sha
-            type=raw,value=latest,enable={{is_default_branch}}
             type=semver,pattern={{version}}
             type=semver,pattern={{major}}.{{minor}}
             type=semver,pattern={{major}}

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 #TODO: use the go-install-tool to install goimports locally if necessary and update docs
 fmt: ## Run go fmt against code.
 	gofmt -l -s -w .
-	goimports -l -w -local github.com/dynatrace-oss/koney
+	goimports -l -w -local github.com/dynatrace-oss/koney .
 
 .PHONY: vet
 vet: ## Run go vet against code.

--- a/Makefile
+++ b/Makefile
@@ -114,7 +114,7 @@ generate: controller-gen ## Generate code containing DeepCopy, DeepCopyInto, and
 #TODO: use the go-install-tool to install goimports locally if necessary and update docs
 fmt: ## Run go fmt against code.
 	gofmt -l -s -w .
-	goimports -l -w -local github.com/dynatrace-oss/koney ./..
+	goimports -l -w -local github.com/dynatrace-oss/koney
 
 .PHONY: vet
 vet: ## Run go vet against code.

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ Currently, Koney supports the deployment of [honeytokens](https://en.wikipedia.o
 Install the operator in your cluster and wait for it to be ready:
 
 ```sh
-kubectl apply -f https://raw.githubusercontent.com/dynatrace-oss/koney/main/dist/install.yaml
+kubectl apply -f https://raw.githubusercontent.com/dynatrace-oss/koney/refs/tags/v0.1.0/dist/install.yaml
 kubectl wait --for=condition=ready pod -n koney-system -l control-plane=controller-manager
 ```
 

--- a/config/default/kustomization.yaml
+++ b/config/default/kustomization.yaml
@@ -158,7 +158,7 @@ kind: Kustomization
 images:
 - name: alert-forwarder
   newName: ghcr.io/dynatrace-oss/koney-alert-forwarder
-  newTag: latest
+  newTag: 0.1.0
 - name: controller
   newName: ghcr.io/dynatrace-oss/koney-controller
-  newTag: latest
+  newTag: 0.1.0

--- a/dist/install.yaml
+++ b/dist/install.yaml
@@ -627,7 +627,7 @@ spec:
         control-plane: controller-manager
     spec:
       containers:
-      - image: ghcr.io/dynatrace-oss/koney-alert-forwarder:latest
+      - image: ghcr.io/dynatrace-oss/koney-alert-forwarder:0.1.0
         livenessProbe:
           httpGet:
             path: /healthz
@@ -657,7 +657,7 @@ spec:
         - --health-probe-bind-address=:8081
         command:
         - /manager
-        image: ghcr.io/dynatrace-oss/koney-controller:latest
+        image: ghcr.io/dynatrace-oss/koney-controller:0.1.0
         livenessProbe:
           httpGet:
             path: /healthz

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -72,10 +72,20 @@ make uninstall
 Build the installer for the image built and published in the registry:
 
 ```sh
-make build-installer VERSION="latest"
+make build-installer VERSION="x.y.z"
 ```
 
 ℹ️ **Note**: The makefile target mentioned above generates an `install.yaml` file in the `dist` directory. This file contains all the resources built with Kustomize, which are necessary to install this project without its dependencies.
+
+### New Release Process
+
+1. Bump the version in the `Makefile`
+2. Bump the version in the `README.md`
+3. Build the installer (see above) with the new version
+4. Commit, tag, push, and let the pipeline push the image to the registry
+5. Create a new release on GitHub
+
+ℹ️ **Note**: Image version tags are formatted as `1.2.3` while git version tags are formatted as `v1.2.3` (with a `v` prefix).
 
 ## 🪲 Debugging
 


### PR DESCRIPTION
The GitHub action should only put the `latest` tag when a new semver (i.e., a new tag) is released, and not whenever we push to main. Additionally, the docs should pin the version and not directly reference the latest main branch.

Also, there was an error with the `goimports` linter task, as it was referencing an incorrect path.