### PR TITLE
Use local buildplatform for cross-compile base

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Build the manager binary
-FROM golang:1.23@sha256:e54daaadd35ebb90fc1404ecdc6eb7338ae13555f71a71856ad96976ae084e44 AS builder
+FROM --platform=$BUILDPLATFORM golang:1.23@sha256:e54daaadd35ebb90fc1404ecdc6eb7338ae13555f71a71856ad96976ae084e44 AS builder
 ARG TARGETOS
 ARG TARGETARCH
 


### PR DESCRIPTION
By explicitly specifying the `--platform=$BUILDPLATFORM` argument as part of the base docker stage, no emulation is required. Coupled with golangs excellent cross compilation support, this drastically speeds up the required time.

Fixes #6