### PR TITLE
ci: Harden GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,6 +8,8 @@ on:
     tags:
     - v*
 
+permissions: {}
+
 env:
   IMAGE_TAG_BASE: ghcr.io/dynatrace-oss/koney
   CONTROLLER_IMAGE: ghcr.io/dynatrace-oss/koney-controller
@@ -17,13 +19,18 @@ jobs:
   build-controller:
     name: Build controller
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: |
           ${{ env.CONTROLLER_IMAGE }}
@@ -36,10 +43,10 @@ jobs:
           type=semver,pattern={{major}}
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Login to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       if: ${{ github.event_name == 'push' }}
       with:
         registry: ghcr.io
@@ -47,7 +54,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push images
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: .
         push: ${{ github.event_name == 'push' }}
@@ -60,13 +67,18 @@ jobs:
   build-alert-forwarder:
     name: Build alert forwarder
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Extract metadata
       id: meta
-      uses: docker/metadata-action@v5
+      uses: docker/metadata-action@c299e40c65443455700f0fdfc63efafe5b349051 # v5
       with:
         images: |
           ${{ env.ALERT_FORWARDER_IMAGE }}
@@ -79,10 +91,10 @@ jobs:
           type=semver,pattern={{major}}
 
     - name: Setup Docker Buildx
-      uses: docker/setup-buildx-action@v3
+      uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f # v3
 
     - name: Login to GHCR
-      uses: docker/login-action@v3
+      uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9 # v3
       if: ${{ github.event_name == 'push' }}
       with:
         registry: ghcr.io
@@ -90,7 +102,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Build and push images
-      uses: docker/build-push-action@v6
+      uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
       with:
         context: ./alert-forwarder
         push: ${{ github.event_name == 'push' }}
@@ -103,16 +115,21 @@ jobs:
   push-chart:
     name: Push Helm chart
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     if: startsWith(github.ref, 'refs/tags/v')
     needs:
     - build-controller
     - build-alert-forwarder
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
 
     - name: Package Helm chart
       run: VERSION=${GITHUB_REF_NAME#v} make helm-package

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -129,7 +129,7 @@ jobs:
         persist-credentials: false
 
     - name: Install Helm
-      uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
     - name: Package Helm chart
       run: VERSION=${GITHUB_REF_NAME#v} make helm-package

--- a/.github/workflows/hooks.yml
+++ b/.github/workflows/hooks.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -11,15 +13,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
 
     - name: Cache pre-commit environments
-      uses: actions/cache@v5
+      uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5
       with:
         path: ~/.cache/pre-commit
         key: ${{ runner.os }}-pre-commit-${{ hashFiles('**/.pre-commit-config.yaml') }}

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -35,7 +35,7 @@ jobs:
       run: make setup-test-e2e
 
     - name: Install Helm
-      uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
     - name: Verify Helm installation
       run: helm version

--- a/.github/workflows/test-chart.yml
+++ b/.github/workflows/test-chart.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
 
 jobs:
   test-chart:
@@ -11,10 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
 
@@ -31,7 +35,7 @@ jobs:
       run: make setup-test-e2e
 
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
 
     - name: Verify Helm installation
       run: helm version

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
 
 jobs:
   test-e2e:
@@ -11,10 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
 
@@ -31,7 +35,7 @@ jobs:
       run: make setup-test-e2e
 
     - name: Install Helm
-      uses: azure/setup-helm@v4
+      uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
 
     - name: Verify Helm installation
       run: helm version

--- a/.github/workflows/test-e2e.yml
+++ b/.github/workflows/test-e2e.yml
@@ -35,7 +35,7 @@ jobs:
       run: make setup-test-e2e
 
     - name: Install Helm
-      uses: azure/setup-helm@bf6a7d304bc2fdb57e0331155b7ebf2c504acf0a # v4
+      uses: azure/setup-helm@1a275c3b69536ee54be43f2070a358922e12c8d4 # v4.3.1
 
     - name: Verify Helm installation
       run: helm version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,6 +4,8 @@ on:
   pull_request:
   push:
 
+permissions:
+  contents: read
 
 jobs:
   test:
@@ -11,10 +13,12 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+      with:
+        persist-credentials: false
 
     - name: Setup Go
-      uses: actions/setup-go@v6
+      uses: actions/setup-go@4a3601121dd01d1626a1e23e37211e3254c1c06c # v6
       with:
         go-version-file: go.mod
 


### PR DESCRIPTION
## Summary
- Pin all action references to SHA hashes to prevent supply chain attacks
- Add explicit least-privilege `permissions` blocks to all workflows
- Set `persist-credentials: false` on all checkout steps