### PR TITLE
fix: Remove unsupported returnArgAction from Tetragon TracingPolicy

### DIFF
--- a/internal/controller/traps/filesystoken/utils.go
+++ b/internal/controller/traps/filesystoken/utils.go
@@ -168,7 +168,6 @@ func generateTetragonTracingPolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
 						Index: 0,
 						Type:  "int", // The int return type is used to trace the return value of the function
 					},
-					ReturnArgAction: "Post", // The Post action is used to trace the return value of the function
 					Selectors: []ciliumiov1alpha1.KProbeSelector{
 						{
 							MatchArgs: []ciliumiov1alpha1.ArgSelector{
@@ -203,7 +202,6 @@ func generateTetragonTracingPolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
 						Index: 0,
 						Type:  "int",
 					},
-					ReturnArgAction: "Post",
 					Selectors: []ciliumiov1alpha1.KProbeSelector{
 						{
 							MatchArgs: []ciliumiov1alpha1.ArgSelector{

--- a/test/e2e/e2e_captor_kive_test.go
+++ b/test/e2e/e2e_captor_kive_test.go
@@ -16,6 +16,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -513,7 +514,9 @@ var _ = Describe("Koney Operator with Kive", Ordered, func() {
 	When("deleting the controller-manager", func() {
 		It("should delete the controller-manager", func() {
 			By("deleting the controller-manager")
-			cmd := exec.Command("timeout", "30s", "make", "undeploy")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "make", "undeploy")
 			_, err := testutils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 		})

--- a/test/e2e/e2e_test.go
+++ b/test/e2e/e2e_test.go
@@ -16,6 +16,7 @@
 package e2e
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"os/exec"
@@ -549,7 +550,9 @@ var _ = Describe("Koney Operator", Ordered, func() {
 	When("deleting the controller-manager", func() {
 		It("should delete the controller-manager", func() {
 			By("deleting the controller-manager")
-			cmd := exec.Command("timeout", "30s", "make", "undeploy")
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+			cmd := exec.CommandContext(ctx, "make", "undeploy")
 			_, err := testutils.Run(cmd)
 			Expect(err).NotTo(HaveOccurred())
 		})


### PR DESCRIPTION
## Summary

- Tetragon `v1.7.0` tightened validation and now rejects `returnArgAction: "Post"` on kprobes, which Koney's generated `TracingPolicy` set on both `security_file_permission` and `security_mmap_file` hooks. The Tetragon agent silently rejects the policy at the sensor-loading level (the CR itself is still accepted by the K8s API), so no kprobe hooks ever attach and honeytoken alerts never fire.
- `Post` was always redundant: `Return: true` + `ReturnArg` already capture the return value in the event, and the `GetUrl` webhook action (used to call the alert-forwarder) is driven by the selector's entry-time `MatchArgs`, independent of `returnArgAction` — which Tetragon's own docs describe as relevant only to the socket-tracking actions `TrackSock`/`UntrackSock`.
- Verified locally against both Tetragon `v1.6.1` (pre-tightening) and `v1.7.0` (current) via `helm upgrade --version <x>` + full e2e suite runs — no regression on the older version.
- Also fixes the e2e "delete the controller-manager" step shelling out to the GNU-only `timeout` binary (doesn't exist on macOS/BSD) by using `context.WithTimeout` + `exec.CommandContext` instead.

Fixes #55

## Test plan

- [x] `go build ./...` / `go vet ./...`
- [x] Full `make test-e2e` suite run against Tetragon `v1.7.0`: Tetragon honeytoken alert test passes
- [x] Full `make test-e2e` suite run against Tetragon `v1.6.1`: Tetragon honeytoken alert test passes (no regression)
- [x] Independent review pass by a second agent confirmed no issues in the diff

🤖 Generated with [Claude Code](https://claude.com/claude-code)