### PR TITLE
fix: prevent command injection through FilesystemHoneytoken file paths

### DIFF
--- a/internal/controller/traps/filesystoken/commands.go
+++ b/internal/controller/traps/filesystoken/commands.go
@@ -1,0 +1,47 @@
+// Copyright (c) 2025 Dynatrace LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package filesystoken
+
+import "strings"
+
+// The dynamic values (file path, octal content and fingerprints) are passed to
+// the shell as positional arguments instead of being interpolated into the
+// script, so the shell never re-parses them as code. The file path in
+// particular comes from the DeceptionPolicy and is attacker-controlled.
+
+func fileExistenceCheckCommand(filePath string) []string {
+	return []string{"sh", "-c", `[ ! -f "$1" ] && echo 'No such file' || echo 'File exists'`, "sh", filePath}
+}
+
+func writeOctalContentCommand(octalContent, echoFingerprint, filePath string) []string {
+	return []string{
+		"sh", "-c",
+		`oct_string="$2"; i=1; while [ $i -lt ${#oct_string} ]; do $(which echo) -e "\0$(expr substr $oct_string $i 3)\c $3"; i=$(expr $i + 3); done > "$1"`,
+		"sh", filePath, octalContent, echoFingerprint,
+	}
+}
+
+func writeEmptyFileCommand(echoFingerprint, filePath string) []string {
+	return []string{"sh", "-c", `echo -e "\c $2" > "$1"`, "sh", filePath, echoFingerprint}
+}
+
+func readFileContentCommand(catFingerprint, filePath string) []string {
+	// catFingerprint is a space-joined list of `-u`/`-uu` flags; pass each as its
+	// own positional arg so cat sees them as flags, with the file last, via "$@".
+	args := []string{"sh", "-c", `cat "$@"`, "sh"}
+	args = append(args, strings.Fields(catFingerprint)...)
+	return append(args, filePath)
+}

--- a/internal/controller/traps/filesystoken/commands_test.go
+++ b/internal/controller/traps/filesystoken/commands_test.go
@@ -1,0 +1,84 @@
+// Copyright (c) 2025 Dynatrace LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package filesystoken
+
+import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestCommandsDoNotInterpolateDynamicValues(t *testing.T) {
+	const filePath = "/run/secrets/token"
+
+	cases := []struct {
+		name   string
+		cmd    []string
+		values []string
+	}{
+		{"existence", fileExistenceCheckCommand(filePath), []string{filePath}},
+		{"octal", writeOctalContentCommand("141142143", "fp", filePath), []string{"141142143", "fp", filePath}},
+		{"empty", writeEmptyFileCommand("fp", filePath), []string{"fp", filePath}},
+		{"read", readFileContentCommand("-u -uu", filePath), []string{"-u", "-uu", filePath}},
+	}
+
+	for _, tc := range cases {
+		if len(tc.cmd) < 5 || tc.cmd[0] != "sh" || tc.cmd[1] != "-c" || tc.cmd[3] != "sh" {
+			t.Fatalf("%s: want an `sh -c <script> sh <args...>` form, got %v", tc.name, tc.cmd)
+		}
+
+		script, positional := tc.cmd[2], tc.cmd[4:]
+		for _, v := range tc.values {
+			if strings.Contains(script, v) {
+				t.Errorf("%s: %q must not be interpolated into the script: %q", tc.name, v, script)
+			}
+			if !contains(positional, v) {
+				t.Errorf("%s: %q must be passed as a positional argument, got %v", tc.name, v, positional)
+			}
+		}
+	}
+}
+
+func TestDynamicValuesAreNotShellInterpreted(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out")
+	marker := filepath.Join(dir, "pwned")
+	inject := "$(touch " + marker + ")"
+
+	for _, cmd := range [][]string{
+		fileExistenceCheckCommand(inject),
+		writeOctalContentCommand(inject, inject, out),
+		writeEmptyFileCommand(inject, out),
+		readFileContentCommand(inject, inject),
+	} {
+		_ = exec.Command(cmd[0], cmd[1:]...).Run() // command errors are irrelevant; only injection matters
+
+		if _, err := os.Stat(marker); !os.IsNotExist(err) {
+			t.Fatalf("a dynamic value was shell-interpreted: injected command ran for %v", cmd)
+		}
+	}
+}
+
+func contains(haystack []string, needle string) bool {
+	for _, s := range haystack {
+		if s == needle {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/controller/traps/filesystoken/deployment.go
+++ b/internal/controller/traps/filesystoken/deployment.go
@@ -242,10 +242,10 @@ func (r *FilesystemHoneytokenReconciler) deployDecoyWithContainerExec(ctx contex
 		// To decode the octal content, we use the following command:
 		// oct_string="141142143"; i=1; while [ $i -lt ${#oct_string} ]; do $(which echo) -e "\0$(expr substr $oct_string $i 3)\c"; i=$(expr $i + 3); done > /path/to/file
 		// $(which echo) is used to avoid issues with the shell built-in echo command
-		cmd = []string{"sh", "-c", "oct_string=\"" + octalContent + "\"; i=1; while [ $i -lt ${#oct_string} ]; do $(which echo) -e \"\\0$(expr substr $oct_string $i 3)\\c " + echoFingerprint + "\"; i=$(expr $i + 3); done > \"" + trap.FilesystemHoneytoken.FilePath + "\""}
+		cmd = writeOctalContentCommand(octalContent, echoFingerprint, trap.FilesystemHoneytoken.FilePath)
 	} else {
 		// We don't use touch because if the file already includes content, touch would not make it empty
-		cmd = []string{"sh", "-c", "echo -e \"\\c " + echoFingerprint + "\" > \"" + trap.FilesystemHoneytoken.FilePath + "\""}
+		cmd = writeEmptyFileCommand(echoFingerprint, trap.FilesystemHoneytoken.FilePath)
 	}
 
 	// Use ExecCMDInContainer to execute the command in the container
@@ -258,7 +258,7 @@ func (r *FilesystemHoneytokenReconciler) deployDecoyWithContainerExec(ctx contex
 		return joinedErrors
 	} else {
 		// Check if the file was created with the expected content
-		cmd = []string{"sh", "-c", "cat " + catFingerprint + " \"" + trap.FilesystemHoneytoken.FilePath + "\""}
+		cmd = readFileContentCommand(catFingerprint, trap.FilesystemHoneytoken.FilePath)
 		output, err := r.executeCommandInContainer(ctx, pod, containerName, cmd)
 		if err != nil {
 			log.Error(err, "unable to read the content of the file", "container", containerName)

--- a/internal/controller/traps/filesystoken/removal.go
+++ b/internal/controller/traps/filesystoken/removal.go
@@ -144,7 +144,7 @@ func (r *FilesystemHoneytokenReconciler) removeDecoyWithContainerExec(ctx contex
 		// Check if the file was removed
 		// ExecCMDInContainer does not run commands in a shell, so we need to use sh -c to do so
 		// The command checks if the file exists and prints "File exists" if it does, or "No such file" if it doesn't
-		cmd = []string{"sh", "-c", "[ ! -f " + trap.FilesystemHoneytoken.FilePath + " ] && echo 'No such file' || echo 'File exists'"}
+		cmd = fileExistenceCheckCommand(trap.FilesystemHoneytoken.FilePath)
 		output, err := r.executeCommandInContainer(ctx, pod, containerName, cmd)
 		if err != nil {
 			log.Error(err, "unable to check if the file was removed", "container", containerName, "stderr", output)


### PR DESCRIPTION
## Summary

`FilesystemHoneytoken.FilePath` comes from a `DeceptionPolicy` and is concatenated directly into shell scripts that the operator runs with `sh -c` inside workload pods. because the path is interpolated into the script text instead of passed as an argument, a crafted path breaks out of the intended command and runs arbitrary shell in the target pod

affected snippets: the file existence check, the octal write, the empty-file write and the file read in `internal/controller/traps/filesystoken/removal.go` and `deployment.go`

## Impact

anyone who can create or edit a `DeceptionPolicy` can run arbitrary commands in the pods that policy selects, with the privileges the operator uses to exec into them. a `filePath` such as `; ...;` or `$(...)` is executed rather than treated as a path

## Fix

the four shell snippets are pulled into a small `commands.go` helper set, and the file path is passed as a positional argument (`sh -c "$SCRIPT" sh "$FILE_PATH"`, read as `$1`) instead of being spliced into the script. the shell now treats it as data, never as code

## How to verify

on the current code, a honeytoken whose `filePath` is `/tmp/x$(touch /tmp/koney-poc)` creates `/tmp/koney-poc` when the trap is deployed or removed - proof the substring is executed. with this change the same value is treated as a literal path and nothing runs. the new `commands_test.go` asserts each command passes the path as `$1` and that an injection-shaped path produces no side effect