### PR TITLE
fix: do not panic when a trap matches resources by namespace only

### DIFF
--- a/api/v1alpha1/dp_trap_types.go
+++ b/api/v1alpha1/dp_trap_types.go
@@ -94,7 +94,7 @@ func (trap *Trap) IsValid() error {
 			return errors.New("MatchResources.Any.Namespaces and MatchResources.Any.Selector are nil")
 		}
 
-		if len(value.Namespaces) == 0 && len(value.Selector.MatchLabels) == 0 {
+		if len(value.Namespaces) == 0 && (value.Selector == nil || len(value.Selector.MatchLabels) == 0) {
 			return errors.New("MatchResources.Any.Namespaces and MatchResources.Any.Selector are empty")
 		}
 

--- a/api/v1alpha1/dp_trap_types_test.go
+++ b/api/v1alpha1/dp_trap_types_test.go
@@ -139,6 +139,21 @@ var _ = Describe("IsValid", func() {
 		})
 	})
 
+	Context("when checking a trap with an empty (non-nil) Namespaces slice and a nil Selector", func() {
+		It("should return error", func() {
+			for _, trap := range testTraps {
+				trap.MatchResources = MatchResources{
+					Any: []ResourceFilter{
+						{ResourceDescription: ResourceDescription{Namespaces: []string{}, Selector: nil}},
+					},
+				}
+				err := trap.IsValid()
+				Expect(err).Should(HaveOccurred())
+				Expect(err.Error()).Should(ContainSubstring("are empty"))
+			}
+		})
+	})
+
 	Context("when checking a trap with both Namespaces and Selector empty", func() {
 		It("should return error", func() {
 			for _, trap := range testTraps {

--- a/internal/controller/traps/filesystoken/utils.go
+++ b/internal/controller/traps/filesystoken/utils.go
@@ -228,6 +228,9 @@ func generateTetragonTracingPolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
 
 	// Add the labels from the trap's MatchResources to the PodSelector
 	for _, resourceFilter := range trap.MatchResources.Any {
+		if resourceFilter.Selector == nil {
+			continue
+		}
 		for key, value := range resourceFilter.Selector.MatchLabels {
 			tracingPolicy.Spec.PodSelector.MatchLabels[key] = value
 		}
@@ -361,6 +364,9 @@ func generateKivePolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
 			}
 
 			for _, resourceFilter := range trap.MatchResources.Any {
+				if resourceFilter.Selector == nil {
+					continue
+				}
 				for key, value := range resourceFilter.Selector.MatchLabels {
 					kiveTrapMatch.MatchLabels[key] = value
 				}
@@ -379,6 +385,9 @@ func generateKivePolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
 				}
 
 				for _, resourceFilter := range trap.MatchResources.Any {
+					if resourceFilter.Selector == nil {
+						continue
+					}
 					for key, value := range resourceFilter.Selector.MatchLabels {
 						kiveTrapMatch.MatchLabels[key] = value
 					}

--- a/internal/controller/traps/filesystoken/utils_test.go
+++ b/internal/controller/traps/filesystoken/utils_test.go
@@ -149,3 +149,49 @@ var _ = Describe("DeployCaptor", func() {
 		})
 	})
 })
+
+var _ = Describe("Policy generation with a namespace-only trap", func() {
+	Context("With a trap that matches resources by namespace and has no label selector", func() {
+		namespaceOnlyTrap := v1alpha1.Trap{
+			FilesystemHoneytoken: v1alpha1.FilesystemHoneytoken{
+				FilePath:    "/path/to/file",
+				FileContent: "someverysecrettoken",
+			},
+			MatchResources: v1alpha1.MatchResources{
+				Any: []v1alpha1.ResourceFilter{
+					{
+						ResourceDescription: v1alpha1.ResourceDescription{
+							Namespaces: []string{"koney"},
+						},
+					},
+				},
+			},
+		}
+
+		It("should generate a Tetragon TracingPolicy without a PodSelector label", func() {
+			deceptionPolicy := v1alpha1.DeceptionPolicy{
+				Spec: v1alpha1.DeceptionPolicySpec{
+					Traps: []v1alpha1.Trap{namespaceOnlyTrap},
+				},
+			}
+			tracingPolicy := generateTetragonTracingPolicy(&deceptionPolicy, namespaceOnlyTrap, "test-tracing-policy")
+			Expect(tracingPolicy.Name).To(Equal("test-tracing-policy"))
+			Expect(tracingPolicy.Spec.PodSelector.MatchLabels).To(BeEmpty())
+		})
+
+		It("should generate a KivePolicy without a match label", func() {
+			deceptionPolicy := v1alpha1.DeceptionPolicy{
+				Spec: v1alpha1.DeceptionPolicySpec{
+					Traps: []v1alpha1.Trap{namespaceOnlyTrap},
+				},
+			}
+			kivePolicy := generateKivePolicy(&deceptionPolicy, namespaceOnlyTrap, "test-kive-policy")
+			Expect(kivePolicy.Name).To(Equal("test-kive-policy"))
+			Expect(kivePolicy.Spec.Traps[0].MatchAny).ToNot(BeEmpty())
+			for _, trapMatch := range kivePolicy.Spec.Traps[0].MatchAny {
+				Expect(trapMatch.Namespace).To(Equal("koney"))
+				Expect(trapMatch.MatchLabels).To(BeEmpty())
+			}
+		})
+	})
+})


### PR DESCRIPTION
## Summary

`MatchResources.Any[].selector` is optional, and the README says a trap only needs one of `namespaces` or `selector`. both policy generators dereference the selector without checking it, so a trap that matches by namespace alone panics the reconcile loop

the timing makes it worse than a plain nil deref: `reconcileDecoys` runs before `reconcileCaptors`, so the honeytoken files are already written into the workload containers when the panic happens. the TracingPolicy or KivePolicy is never created, so the decoys sit there with nothing watching them, and the panic repeats on every reconcile

a minimal policy that triggers it:

```yaml
traps:
  - filesystemHoneytoken:
      filePath: /run/secrets/token
      fileContent: some-token
    match:
      any:
        - resources:
            namespaces: [koney-demo]
```

## Changes

skip resource filters that have no selector, which is what the decoy path in `matching.go` already does (lines 175 and 199). the three affected spots are `generateTetragonTracingPolicy` and both branches of `generateKivePolicy`

## Testing

added a spec that generates both policy types from a namespace-only trap. it panics with `invalid memory address or nil pointer dereference` before the change and passes after

`go test ./internal/... ./api/...` is green. the `internal/controller` suite needs the envtest binaries, which I do not have locally, and it fails the same way on an unmodified checkout