### PR TITLE
fix: react to label changes on pods again

### DIFF
--- a/internal/controller/deceptionpolicy_controller.go
+++ b/internal/controller/deceptionpolicy_controller.go
@@ -319,36 +319,39 @@ func (r *DeceptionPolicyReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		Named("deceptionpolicy").
 		Watches(&corev1.Pod{}, watchHandler).
 		Watches(&appsv1.Deployment{}, watchHandler).
-		WithEventFilter(predicate.Funcs{
-			GenericFunc: func(e event.GenericEvent) bool { return false },
-			CreateFunc:  func(e event.CreateEvent) bool { return true },
-			UpdateFunc: func(e event.UpdateEvent) bool {
-				switch e.ObjectNew.(type) {
-				case *corev1.Pod:
-				case *appsv1.Deployment:
-					// For pods and deployments, consider generation changes and label changes
-					// - Generation changes means spec changes, e.g., new container images that need new decoys
-					// - Label changes could affect what is matched by the deception policies
-					return predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}).Update(e)
-				case *v1alpha1.DeceptionPolicy:
-					// For deception policies, only consider generation changes
-					// (skips update on status, metadata, labels, etc.)
-					return predicate.GenerationChangedPredicate{}.Update(e)
-				}
-				return false
-			},
-			DeleteFunc: func(e event.DeleteEvent) bool {
-				switch e.Object.(type) {
-				case *corev1.Pod:
-				case *appsv1.Deployment:
-					// The controller must not change anything when pods or deployments are deleted,
-					// only the status conditions will be incorrect until the next periodic reconciliation
-					return false
-				case *v1alpha1.DeceptionPolicy:
-					return true
-				}
-				return false
-			},
-		}).
+		WithEventFilter(deceptionPolicyEventFilter()).
 		Complete(r)
+}
+
+// deceptionPolicyEventFilter decides which events reach the reconciler.
+func deceptionPolicyEventFilter() predicate.Funcs {
+	return predicate.Funcs{
+		GenericFunc: func(e event.GenericEvent) bool { return false },
+		CreateFunc:  func(e event.CreateEvent) bool { return true },
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			switch e.ObjectNew.(type) {
+			case *corev1.Pod, *appsv1.Deployment:
+				// For pods and deployments, consider generation changes and label changes
+				// - Generation changes means spec changes, e.g., new container images that need new decoys
+				// - Label changes could affect what is matched by the deception policies
+				return predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}).Update(e)
+			case *v1alpha1.DeceptionPolicy:
+				// For deception policies, only consider generation changes
+				// (skips update on status, metadata, labels, etc.)
+				return predicate.GenerationChangedPredicate{}.Update(e)
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			switch e.Object.(type) {
+			case *corev1.Pod, *appsv1.Deployment:
+				// The controller must not change anything when pods or deployments are deleted,
+				// only the status conditions will be incorrect until the next periodic reconciliation
+				return false
+			case *v1alpha1.DeceptionPolicy:
+				return true
+			}
+			return false
+		},
+	}
 }

--- a/internal/controller/deceptionpolicy_controller_test.go
+++ b/internal/controller/deceptionpolicy_controller_test.go
@@ -20,8 +20,11 @@ import (
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/event"
 	"sigs.k8s.io/controller-runtime/pkg/reconcile"
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -89,4 +92,37 @@ var _ = Describe("DeceptionPolicy Controller", func() {
 		})
 	})
 
+})
+
+var _ = Describe("deceptionPolicyEventFilter", func() {
+	const testNamespace = "koney"
+
+	Context("When a pod or deployment is updated", func() {
+		It("should pass a pod update that changes labels", func() {
+			oldPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: testNamespace}}
+			newPod := oldPod.DeepCopy()
+			newPod.Labels = map[string]string{"demo.koney/honeytoken": "true"}
+
+			passed := deceptionPolicyEventFilter().Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod})
+			Expect(passed).To(BeTrue())
+		})
+
+		It("should pass a deployment update that changes labels", func() {
+			oldDeployment := &appsv1.Deployment{ObjectMeta: metav1.ObjectMeta{Name: "deployment", Namespace: testNamespace}}
+			newDeployment := oldDeployment.DeepCopy()
+			newDeployment.Labels = map[string]string{"demo.koney/honeytoken": "true"}
+
+			passed := deceptionPolicyEventFilter().Update(event.UpdateEvent{ObjectOld: oldDeployment, ObjectNew: newDeployment})
+			Expect(passed).To(BeTrue())
+		})
+
+		It("should drop a pod update that only changes the status", func() {
+			oldPod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "pod", Namespace: testNamespace}}
+			newPod := oldPod.DeepCopy()
+			newPod.Status.Phase = corev1.PodRunning
+
+			passed := deceptionPolicyEventFilter().Update(event.UpdateEvent{ObjectOld: oldPod, ObjectNew: newPod})
+			Expect(passed).To(BeFalse())
+		})
+	})
 })


### PR DESCRIPTION
the update filter in `SetupWithManager` has an empty `case *corev1.Pod:` sitting in front of the deployment case:

```go
switch e.ObjectNew.(type) {
case *corev1.Pod:
case *appsv1.Deployment:
    // For pods and deployments, consider generation changes and label changes
    return predicate.Or(predicate.GenerationChangedPredicate{}, predicate.LabelChangedPredicate{}).Update(e)
```

go type switches do not fall through, so a pod update matches the first case, runs nothing and falls out to `return false`. the `Watches(&corev1.Pod{}, watchHandler)` two lines above therefore never fires on updates, and `LabelChangedPredicate` is dead for pods

in practice: labelling a running pod so that a policy should now match it does not enqueue a reconcile, so the honeytoken never arrives. removing the label does not trigger cleanup either. the pod only gets picked up when something else happens to reconcile the policy

the comment on the deployment case says "For pods **and** deployments", so both kinds were meant to share that predicate

## changes

merged the two cases, and did the same in `DeleteFunc` where the shape is identical (harmless there, both branches return false, but it reads as the same mistake)

moved the filter into `deceptionPolicyEventFilter()` so it can be exercised without standing up a manager

## testing

three specs: a pod update that changes labels must pass, a deployment update that changes labels must pass, and a pod update that only changes status must still be dropped. that last one pins that this does not open the door to status churn

before the change the first spec fails, after it all three pass. `go test ./internal/... ./api/...` is green with the envtest binaries from `make setup-envtest`