### PR TITLE
fix: identify matched workloads by namespace and name

### DIFF
--- a/internal/controller/matching/matching.go
+++ b/internal/controller/matching/matching.go
@@ -125,7 +125,7 @@ func getMatchingObjectsWithContainers(r client.Reader, ctx context.Context, matc
 				continue // If no containers match the containerSelector, skip the object
 			} else {
 				// If the object is already in the map, append the selected containers to the existing list (avoiding duplicates)
-				objectFromMap := getObjectFromMap(matchingObject.GetName(), matchingObjectsWithContainers)
+				objectFromMap := getObjectFromMap(client.ObjectKeyFromObject(matchingObject), matchingObjectsWithContainers)
 				if objectFromMap != nil {
 					containers := matchingObjectsWithContainers[objectFromMap]
 
@@ -165,7 +165,7 @@ func getMatchingObjectsByNamespaceAndLabels(r client.Reader, ctx context.Context
 			}
 
 			for _, object := range items {
-				if !utils.Contains(extractObjectNames(matchingByNamespace), object.GetName()) {
+				if !utils.Contains(extractObjectKeys(matchingByNamespace), client.ObjectKeyFromObject(object)) {
 					matchingByNamespace = append(matchingByNamespace, object)
 				}
 			}
@@ -179,7 +179,7 @@ func getMatchingObjectsByNamespaceAndLabels(r client.Reader, ctx context.Context
 			return nil, err
 		} else {
 			for _, object := range items {
-				if !utils.Contains(extractObjectNames(matchingByLabels), object.GetName()) {
+				if !utils.Contains(extractObjectKeys(matchingByLabels), client.ObjectKeyFromObject(object)) {
 					matchingByLabels = append(matchingByLabels, object)
 				}
 			}
@@ -189,7 +189,7 @@ func getMatchingObjectsByNamespaceAndLabels(r client.Reader, ctx context.Context
 	// If no namespaces are specified, add all the objects that match the labels
 	if len(resourceFilter.Namespaces) == 0 {
 		for _, object := range matchingByLabels {
-			if !utils.Contains(extractObjectNames(matchingObjects), object.GetName()) {
+			if !utils.Contains(extractObjectKeys(matchingObjects), client.ObjectKeyFromObject(object)) {
 				matchingObjects = append(matchingObjects, object)
 			}
 		}
@@ -198,7 +198,7 @@ func getMatchingObjectsByNamespaceAndLabels(r client.Reader, ctx context.Context
 	// If no labels are specified, add all the objects that match the namespaces
 	if resourceFilter.Selector == nil || len(resourceFilter.Selector.MatchLabels) == 0 {
 		for _, object := range matchingByNamespace {
-			if !utils.Contains(extractObjectNames(matchingObjects), object.GetName()) {
+			if !utils.Contains(extractObjectKeys(matchingObjects), client.ObjectKeyFromObject(object)) {
 				matchingObjects = append(matchingObjects, object)
 			}
 		}
@@ -207,8 +207,8 @@ func getMatchingObjectsByNamespaceAndLabels(r client.Reader, ctx context.Context
 	// If both namespaces and labels are specified, add the objects that match both (logical AND between namespaces and labels)
 	for _, objectByNamespace := range matchingByNamespace {
 		for _, objectByLabels := range matchingByLabels {
-			if objectByNamespace.GetName() == objectByLabels.GetName() {
-				if !utils.Contains(extractObjectNames(matchingObjects), objectByNamespace.GetName()) {
+			if client.ObjectKeyFromObject(objectByNamespace) == client.ObjectKeyFromObject(objectByLabels) {
+				if !utils.Contains(extractObjectKeys(matchingObjects), client.ObjectKeyFromObject(objectByNamespace)) {
 					matchingObjects = append(matchingObjects, objectByNamespace)
 				}
 			}

--- a/internal/controller/matching/matching_test.go
+++ b/internal/controller/matching/matching_test.go
@@ -434,7 +434,7 @@ var _ = Describe("GetDeployableObjectsWithContainers", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(matchResult.DeployableObjects).To(HaveLen(1))
-			obj := getObjectFromMap(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Name, matchResult.DeployableObjects)
+			obj := getObjectFromMap(client.ObjectKeyFromObject(&podOk_Old_Run_CtrsReady_Ctr1RunAndReady), matchResult.DeployableObjects)
 			Expect(obj).NotTo(BeNil())
 			Expect(obj.GetName()).To(Equal(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Name))
 			Expect(matchResult.DeployableObjects[obj]).To(HaveLen(1))
@@ -462,7 +462,7 @@ var _ = Describe("GetDeployableObjectsWithContainers", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(matchResult.DeployableObjects).To(HaveLen(1))
-			obj := getObjectFromMap(podOk_New_Run_CtrsReady_Ctr1RunAndReady.Name, matchResult.DeployableObjects)
+			obj := getObjectFromMap(client.ObjectKeyFromObject(&podOk_New_Run_CtrsReady_Ctr1RunAndReady), matchResult.DeployableObjects)
 			Expect(obj).NotTo(BeNil())
 			Expect(obj.GetName()).To(Equal(podOk_New_Run_CtrsReady_Ctr1RunAndReady.Name))
 			Expect(matchResult.DeployableObjects[obj]).To(HaveLen(1))
@@ -488,13 +488,13 @@ var _ = Describe("GetDeployableObjectsWithContainers", func() {
 
 			Expect(matchResult.DeployableObjects).To(HaveLen(2))
 
-			obj1 := getObjectFromMap(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Name, matchResult.DeployableObjects)
+			obj1 := getObjectFromMap(client.ObjectKeyFromObject(&podOk_Old_Run_CtrsReady_Ctr1RunAndReady), matchResult.DeployableObjects)
 			Expect(obj1).NotTo(BeNil())
 			Expect(obj1.GetName()).To(Equal(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Name))
 			Expect(matchResult.DeployableObjects[obj1]).To(HaveLen(1))
 			Expect(matchResult.DeployableObjects[obj1][0]).To(Equal(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Spec.Containers[0].Name))
 
-			obj2 := getObjectFromMap(podOk_New_Run_CtrsReady_Ctr1RunAndReady.Name, matchResult.DeployableObjects)
+			obj2 := getObjectFromMap(client.ObjectKeyFromObject(&podOk_New_Run_CtrsReady_Ctr1RunAndReady), matchResult.DeployableObjects)
 			Expect(obj2).NotTo(BeNil())
 			Expect(obj2.GetName()).To(Equal(podOk_New_Run_CtrsReady_Ctr1RunAndReady.Name))
 			Expect(matchResult.DeployableObjects[obj2]).To(HaveLen(1))
@@ -523,7 +523,7 @@ var _ = Describe("GetDeployableObjectsWithContainers", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(matchResult.DeployableObjects).To(HaveLen(1))
-			obj := getObjectFromMap(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Name, matchResult.DeployableObjects)
+			obj := getObjectFromMap(client.ObjectKeyFromObject(&podOk_Old_Run_CtrsReady_Ctr1RunAndReady), matchResult.DeployableObjects)
 			Expect(obj).NotTo(BeNil())
 			Expect(obj.GetName()).To(Equal(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Name))
 			Expect(matchResult.DeployableObjects[obj]).To(HaveLen(1))
@@ -553,13 +553,13 @@ var _ = Describe("GetDeployableObjectsWithContainers", func() {
 
 			Expect(matchResult.DeployableObjects).To(HaveLen(2))
 
-			obj1 := getObjectFromMap(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Name, matchResult.DeployableObjects)
+			obj1 := getObjectFromMap(client.ObjectKeyFromObject(&podOk_Old_Run_CtrsReady_Ctr1RunAndReady), matchResult.DeployableObjects)
 			Expect(obj1).NotTo(BeNil())
 			Expect(obj1.GetName()).To(Equal(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Name))
 			Expect(matchResult.DeployableObjects[obj1]).To(HaveLen(1))
 			Expect(matchResult.DeployableObjects[obj1][0]).To(Equal(podOk_Old_Run_CtrsReady_Ctr1RunAndReady.Spec.Containers[0].Name))
 
-			obj2 := getObjectFromMap(podOk_Old_Run_CtrsNotReady_Ctr1RunAndReady_Ctr2RunAndNotReady.Name, matchResult.DeployableObjects)
+			obj2 := getObjectFromMap(client.ObjectKeyFromObject(&podOk_Old_Run_CtrsNotReady_Ctr1RunAndReady_Ctr2RunAndNotReady), matchResult.DeployableObjects)
 			Expect(obj2).NotTo(BeNil())
 			Expect(obj2.GetName()).To(Equal(podOk_Old_Run_CtrsNotReady_Ctr1RunAndReady_Ctr2RunAndNotReady.Name))
 			Expect(matchResult.DeployableObjects[obj2]).To(HaveLen(1))
@@ -605,7 +605,7 @@ var _ = Describe("GetDeployableObjectsWithContainers", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(matchResult.DeployableObjects).To(HaveLen(1))
-			obj := getObjectFromMap(deplOk_Old_Available.Name, matchResult.DeployableObjects)
+			obj := getObjectFromMap(client.ObjectKeyFromObject(&deplOk_Old_Available), matchResult.DeployableObjects)
 			Expect(obj).NotTo(BeNil())
 			Expect(obj.GetName()).To(Equal(deplOk_Old_Available.Name))
 			Expect(matchResult.DeployableObjects[obj]).To(HaveLen(1))
@@ -632,7 +632,7 @@ var _ = Describe("GetDeployableObjectsWithContainers", func() {
 			Expect(err).ToNot(HaveOccurred())
 
 			Expect(matchResult.DeployableObjects).To(HaveLen(1))
-			obj := getObjectFromMap(deplOk_Old_Available.Name, matchResult.DeployableObjects)
+			obj := getObjectFromMap(client.ObjectKeyFromObject(&deplOk_Old_Available), matchResult.DeployableObjects)
 			Expect(obj).NotTo(BeNil())
 			Expect(obj.GetName()).To(Equal(deplOk_Old_Available.Name))
 			Expect(matchResult.DeployableObjects[obj]).To(HaveLen(1))
@@ -1268,5 +1268,66 @@ var _ = Describe("selectContainers", func() {
 			Expect(err).ToNot(HaveOccurred())
 			Expect(selection).To(ConsistOf("bar", "baz"))
 		})
+	})
+})
+
+var _ = Describe("Matching across namespaces", func() {
+	var ctx context.Context
+
+	const (
+		FirstNamespace  = "team-a"
+		SecondNamespace = "team-b"
+		LabelKey        = "koney/match"
+		LabelValue      = "yes"
+	)
+
+	makePod := func(name, namespace string, labels map[string]string) corev1.Pod {
+		return corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: namespace, Labels: labels},
+			Spec:       corev1.PodSpec{Containers: []corev1.Container{{Name: "app"}}},
+		}
+	}
+
+	BeforeEach(func() {
+		ctx = context.Background()
+	})
+
+	It("should not select a pod through a label carried by a same-named pod elsewhere", func() {
+		unlabelled := makePod("web", FirstNamespace, nil)
+		labelledElsewhere := makePod("web", SecondNamespace, map[string]string{LabelKey: LabelValue})
+		fakeClient := fake.NewClientBuilder().
+			WithLists(&corev1.PodList{Items: []corev1.Pod{unlabelled, labelledElsewhere}}).Build()
+
+		match := v1alpha1.MatchResources{Any: []v1alpha1.ResourceFilter{{
+			ResourceDescription: v1alpha1.ResourceDescription{
+				Namespaces: []string{FirstNamespace},
+				Selector:   &metav1.LabelSelector{MatchLabels: map[string]string{LabelKey: LabelValue}},
+			},
+		}}}
+
+		matchingPods, err := getMatchingPodsWithContainers(fakeClient, ctx, match)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(matchingPods).To(BeEmpty())
+	})
+
+	It("should select same-named pods in every requested namespace", func() {
+		first := makePod("api", FirstNamespace, map[string]string{LabelKey: LabelValue})
+		second := makePod("api", SecondNamespace, map[string]string{LabelKey: LabelValue})
+		fakeClient := fake.NewClientBuilder().
+			WithLists(&corev1.PodList{Items: []corev1.Pod{first, second}}).Build()
+
+		match := v1alpha1.MatchResources{Any: []v1alpha1.ResourceFilter{{
+			ResourceDescription: v1alpha1.ResourceDescription{
+				Namespaces: []string{FirstNamespace, SecondNamespace},
+			},
+		}}}
+
+		matchingPods, err := getMatchingPodsWithContainers(fakeClient, ctx, match)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(utils.GetMapKeys(matchingPods)).To(HaveLen(2))
+		Expect(extractObjectKeys(utils.GetMapKeys(matchingPods))).To(ConsistOf(
+			client.ObjectKey{Namespace: FirstNamespace, Name: "api"},
+			client.ObjectKey{Namespace: SecondNamespace, Name: "api"},
+		))
 	})
 })

--- a/internal/controller/matching/matchutils.go
+++ b/internal/controller/matching/matchutils.go
@@ -45,10 +45,19 @@ func extractObjectNames(objects []client.Object) []string {
 	return names
 }
 
-// getObjectFromMap returns an object from a map of objects based on its name.
-func getObjectFromMap(objectName string, objectMap map[client.Object][]string) client.Object {
+// extractObjectKeys is a helper function that extracts the namespaced names of the objects from a list of objects.
+func extractObjectKeys(objects []client.Object) []client.ObjectKey {
+	keys := make([]client.ObjectKey, len(objects))
+	for i, podOrDeployment := range objects {
+		keys[i] = client.ObjectKeyFromObject(podOrDeployment)
+	}
+	return keys
+}
+
+// getObjectFromMap returns an object from a map of objects based on its namespaced name.
+func getObjectFromMap(objectKey client.ObjectKey, objectMap map[client.Object][]string) client.Object {
 	for object := range objectMap {
-		if object.GetName() == objectName {
+		if client.ObjectKeyFromObject(object) == objectKey {
 			return object
 		}
 	}


### PR DESCRIPTION
`getMatchingObjectsByNamespaceAndLabels` builds two lists and joins them, but every dedup and join compares the bare `GetName()`:

```go
if objectByNamespace.GetName() == objectByLabels.GetName() {
```

the namespace list is built with `client.InNamespace(...)`, while the label list comes from a cluster-wide `List` with only `client.MatchingLabels(...)`. so the two sides are not comparable on name alone

two things follow, and both are silent because the status still reports success

**a workload that was never selected gets a honeytoken.** namespaces `dev` and `prod` each run something called `web`, only `prod/web` carries the label. a trap scoped to `namespaces: [dev]` plus that label selector should match nothing, but `prod/web` satisfies the label side, `dev/web` satisfies the namespace side, the names are equal, and `dev/web` comes back as matched

**a workload that was selected is skipped.** with `namespaces: [team-a, team-b]` and a deployment named `api` in both, the first is appended and the second is dropped by the name-only `Contains` check. this is the more likely one to hit in practice, since the decoy strategy defaults to `volumeMount`, which matches deployments, and identically named deployments across namespaces are normal

## changes

key on the namespaced name, the way `HandleWatchEvent` already builds identity for these same objects. `extractObjectKeys` and the map lookup now use `client.ObjectKeyFromObject`. `extractObjectNames` stays, the tests use it for readable assertions

## testing

two specs: a pod must not be selected through a label carried by a same-named pod in another namespace, and same-named pods in two requested namespaces must both be selected

both fail if identity is put back to name only, and pass with the change. the existing matching specs pass untouched, and `go test ./internal/... ./api/...` is green