### PR TITLE
fix: do not panic when a trap annotation does not match the resource type

### DIFF
--- a/internal/controller/traps/filesystoken/removal.go
+++ b/internal/controller/traps/filesystoken/removal.go
@@ -43,9 +43,6 @@ func (r *FilesystemHoneytokenReconciler) RemoveDecoy(ctx context.Context, crdNam
 	for _, containerName := range trap.Containers {
 		switch trap.DeploymentStrategy {
 		case "containerExec":
-			// The strategy is read from the annotation, so it may not match the type of the
-			// resource that carries it. Check the type instead of asserting it, as we do when
-			// we deploy the trap, otherwise a wrong annotation would panic the reconciliation.
 			pod, ok := resource.(*corev1.Pod)
 			if !ok {
 				log.Error(nil, "containerExec strategy on a resource that is not a pod", "resource", resource.GetName())

--- a/internal/controller/traps/filesystoken/removal.go
+++ b/internal/controller/traps/filesystoken/removal.go
@@ -43,7 +43,16 @@ func (r *FilesystemHoneytokenReconciler) RemoveDecoy(ctx context.Context, crdNam
 	for _, containerName := range trap.Containers {
 		switch trap.DeploymentStrategy {
 		case "containerExec":
-			pod := resource.(*corev1.Pod)
+			// The strategy is read from the annotation, so it may not match the type of the
+			// resource that carries it. Check the type instead of asserting it, as we do when
+			// we deploy the trap, otherwise a wrong annotation would panic the reconciliation.
+			pod, ok := resource.(*corev1.Pod)
+			if !ok {
+				log.Error(nil, "containerExec strategy on a resource that is not a pod", "resource", resource.GetName())
+				joinedErrors = errors.Join(joinedErrors, errors.New("containerExec strategy on a resource that is not a pod"))
+				continue
+			}
+
 			if err := r.removeDecoyWithContainerExec(ctx, trap, *pod, containerName); err != nil {
 				log.Error(err, "unable to remove FilesystemHoneytoken trap from container", "container", containerName)
 				joinedErrors = errors.Join(joinedErrors, err)
@@ -52,7 +61,13 @@ func (r *FilesystemHoneytokenReconciler) RemoveDecoy(ctx context.Context, crdNam
 			}
 
 		case "volumeMount":
-			deployment := resource.(*appsv1.Deployment)
+			deployment, ok := resource.(*appsv1.Deployment)
+			if !ok {
+				log.Error(nil, "volumeMount strategy on a resource that is not a deployment", "resource", resource.GetName())
+				joinedErrors = errors.Join(joinedErrors, errors.New("volumeMount strategy on a resource that is not a deployment"))
+				continue
+			}
+
 			if err := r.removeDecoyWithVolumeMount(ctx, trap, *deployment, containerName); err != nil {
 				log.Error(err, "unable to remove FilesystemHoneytoken trap from container", "container", containerName)
 				joinedErrors = errors.Join(joinedErrors, err)

--- a/internal/controller/traps/filesystoken/removal_test.go
+++ b/internal/controller/traps/filesystoken/removal_test.go
@@ -1,0 +1,76 @@
+// Copyright (c) 2025 Dynatrace LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package filesystoken
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/dynatrace-oss/koney/api/v1alpha1"
+)
+
+// newRemovalReconciler returns a reconciler backed by a fake client that knows the given objects.
+func newRemovalReconciler(objects ...client.Object) *FilesystemHoneytokenReconciler {
+	scheme := runtime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return &FilesystemHoneytokenReconciler{Client: fakeClient, Scheme: scheme}
+}
+
+var _ = Describe("RemoveDecoy", func() {
+	Context("when the annotation says containerExec but the resource is a deployment", func() {
+		It("should return an error instead of panicking", func() {
+			deployment := &appsv1.Deployment{
+				ObjectMeta: metav1.ObjectMeta{Name: "web", Namespace: "test-namespace"},
+			}
+			trap := v1alpha1.TrapAnnotation{DeploymentStrategy: "containerExec", Containers: []string{"app"}}
+
+			r := newRemovalReconciler(deployment)
+			var err error
+			Expect(func() {
+				err = r.RemoveDecoy(context.Background(), "policy-a", trap, deployment)
+			}).ShouldNot(Panic())
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("is not a pod"))
+		})
+	})
+
+	Context("when the annotation says volumeMount but the resource is a pod", func() {
+		It("should return an error instead of panicking", func() {
+			pod := &corev1.Pod{ObjectMeta: metav1.ObjectMeta{Name: "web-0", Namespace: "test-namespace"}}
+			trap := v1alpha1.TrapAnnotation{DeploymentStrategy: "volumeMount", Containers: []string{"app"}}
+
+			r := newRemovalReconciler(pod)
+			var err error
+			Expect(func() {
+				err = r.RemoveDecoy(context.Background(), "policy-a", trap, pod)
+			}).ShouldNot(Panic())
+			Expect(err).Should(HaveOccurred())
+			Expect(err.Error()).Should(ContainSubstring("is not a deployment"))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

`RemoveDecoy` picks its branch from `trap.DeploymentStrategy`, which is read back from the `koney/changes` annotation, and then hard-asserts the resource type:

```go
case "containerExec":
    pod := resource.(*corev1.Pod)
```

`GetAnnotatedResources` returns a mixed list of pods and deployments, selected only by the presence of the annotation, so the strategy string and the concrete type can disagree. a deployment carrying a schema-valid annotation with `deploymentStrategy: containerExec` makes this assert panic the reconcile loop, and the mirrored case does the same for a pod annotated with `volumeMount`

the deploy path already handles this safely with `if pod, ok := resource.(*corev1.Pod); ok`, the removal path did not

two things make it worth fixing rather than leaving it to `RecoverPanic`:

**the annotation is not a trusted input** - anyone with `patch` on a pod or deployment can write it, which is a far more common grant than write access on a `DeceptionPolicy`, and the key has no reserved prefix

**the failure is sticky** - controller-runtime turns the panic into a reconcile error, so `cleanupDeceptionPolicy` keeps failing, the `koney/finalizer` is never removed and the `DeceptionPolicy` stays in `Terminating` until someone patches the finalizers by hand

this mirrors the safe form from `deployment.go` and logs the mismatch instead of asserting. added tests for both mismatched strategy and type combinations, they panic without the change
