### PR TITLE
fix: skip resources with unparsable trap annotations instead of failing

### DIFF
--- a/internal/controller/annotations/annotated_resources_test.go
+++ b/internal/controller/annotations/annotated_resources_test.go
@@ -1,0 +1,118 @@
+// Copyright (c) 2025 Dynatrace LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package annotations
+
+import (
+	"context"
+	"encoding/json"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/dynatrace-oss/koney/api/v1alpha1"
+	"github.com/dynatrace-oss/koney/internal/controller/constants"
+)
+
+// newAnnotatedPod returns a pod that carries a valid trap annotation for the given DeceptionPolicy.
+func newAnnotatedPod(name string, crdName string) *corev1.Pod {
+	changes := []v1alpha1.ChangeAnnotation{{
+		DeceptionPolicyName: crdName,
+		Traps: []v1alpha1.TrapAnnotation{{
+			DeploymentStrategy: "containerExec",
+			Containers:         []string{"container1"},
+			FilesystemHoneytoken: v1alpha1.FilesystemHoneytokenAnnotation{
+				FilePath:        testFilePath,
+				FileContentHash: testFileHash,
+			},
+		}},
+	}}
+
+	changesJson, err := json.Marshal(changes)
+	Expect(err).ShouldNot(HaveOccurred())
+
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   testNamespace,
+			Annotations: map[string]string{constants.AnnotationKeyChanges: string(changesJson)},
+		},
+	}
+}
+
+// newPodWithBrokenAnnotation returns a pod whose trap annotation cannot be parsed.
+func newPodWithBrokenAnnotation(name string) *corev1.Pod {
+	return &corev1.Pod{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:        name,
+			Namespace:   testNamespace,
+			Annotations: map[string]string{constants.AnnotationKeyChanges: "-"},
+		},
+	}
+}
+
+var _ = Describe("GetAnnotatedResources", func() {
+	var scheme *runtime.Scheme
+
+	BeforeEach(func() {
+		scheme = runtime.NewScheme()
+		Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	})
+
+	newClient := func(objects ...client.Object) client.Reader {
+		return fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	}
+
+	Context("when all resources carry valid annotations", func() {
+		It("should return the annotated resources", func() {
+			r := newClient(newAnnotatedPod(testPodName, testCrdName))
+
+			resources, err := GetAnnotatedResources(r, context.Background(), testCrdName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(resources).Should(HaveLen(1))
+			Expect(resources[0].GetName()).Should(Equal(testPodName))
+		})
+	})
+
+	Context("when another resource carries an annotation that cannot be parsed", func() {
+		It("should skip that resource and still return the others", func() {
+			r := newClient(
+				newPodWithBrokenAnnotation("broken-pod"),
+				newAnnotatedPod(testPodName, testCrdName),
+			)
+
+			resources, err := GetAnnotatedResources(r, context.Background(), testCrdName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(resources).Should(HaveLen(1))
+			Expect(resources[0].GetName()).Should(Equal(testPodName))
+		})
+	})
+
+	Context("when the only resource carries an annotation that cannot be parsed", func() {
+		It("should return no resources and no error, so that clean-up can finish", func() {
+			r := newClient(newPodWithBrokenAnnotation("broken-pod"))
+
+			resources, err := GetAnnotatedResources(r, context.Background(), testCrdName)
+			Expect(err).ShouldNot(HaveOccurred())
+			Expect(resources).Should(BeEmpty())
+		})
+	})
+})

--- a/internal/controller/annotations/annotations.go
+++ b/internal/controller/annotations/annotations.go
@@ -24,6 +24,7 @@ import (
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8slog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/dynatrace-oss/koney/api/v1alpha1"
 	"github.com/dynatrace-oss/koney/internal/controller/constants"
@@ -278,8 +279,13 @@ func AreTheSameTrap(annotationTrap v1alpha1.TrapAnnotation, trap v1alpha1.Trap) 
 	return true
 }
 
-// GetAnnotatedResources returns a list of resources that have been annotated with a specific DeceptionPolicy
+// GetAnnotatedResources returns a list of resources that have been annotated with a specific DeceptionPolicy.
+// Resources whose annotation cannot be parsed are skipped, because we list all pods and deployments
+// in the cluster here, and anyone who can annotate a single resource would otherwise stop the
+// reconciliation of every DeceptionPolicy, including the clean-up that removes their finalizers.
 func GetAnnotatedResources(r client.Reader, ctx context.Context, crdName string) ([]client.Object, error) {
+	log := k8slog.FromContext(ctx)
+
 	var annotatedResources []client.Object
 
 	// Get all pods
@@ -291,7 +297,8 @@ func GetAnnotatedResources(r client.Reader, ctx context.Context, crdName string)
 	for _, pod := range pods.Items {
 		annotationChange, err := GetAnnotationChange(&pod, crdName)
 		if err != nil {
-			return nil, err
+			log.Error(err, "unable to read trap annotations, skipping resource", "pod", pod.Name, "namespace", pod.Namespace)
+			continue
 		}
 
 		if len(annotationChange.Traps) > 0 {
@@ -308,7 +315,8 @@ func GetAnnotatedResources(r client.Reader, ctx context.Context, crdName string)
 	for _, deployment := range deployments.Items {
 		annotationChange, err := GetAnnotationChange(&deployment, crdName)
 		if err != nil {
-			return nil, err
+			log.Error(err, "unable to read trap annotations, skipping resource", "deployment", deployment.Name, "namespace", deployment.Namespace)
+			continue
 		}
 
 		if len(annotationChange.Traps) > 0 {

--- a/internal/controller/annotations/annotations.go
+++ b/internal/controller/annotations/annotations.go
@@ -280,9 +280,7 @@ func AreTheSameTrap(annotationTrap v1alpha1.TrapAnnotation, trap v1alpha1.Trap) 
 }
 
 // GetAnnotatedResources returns a list of resources that have been annotated with a specific DeceptionPolicy.
-// Resources whose annotation cannot be parsed are skipped, because we list all pods and deployments
-// in the cluster here, and anyone who can annotate a single resource would otherwise stop the
-// reconciliation of every DeceptionPolicy, including the clean-up that removes their finalizers.
+// Resources whose annotation cannot be parsed are skipped.
 func GetAnnotatedResources(r client.Reader, ctx context.Context, crdName string) ([]client.Object, error) {
 	log := k8slog.FromContext(ctx)
 


### PR DESCRIPTION
## Summary

`GetAnnotatedResources` lists every pod and deployment in the cluster and gives up on the first one whose `koney/changes` annotation does not parse:

```go
annotationChange, err := GetAnnotationChange(&pod, crdName)
if err != nil {
    return nil, err
}
```

nothing filters, quarantines or skips the bad object, so a single unrelated resource takes the whole listing down

a pod with `koney/changes: "-"`, set by anyone who can create a pod in any namespace, by a GitOps template or by a hand edit, then has cluster-wide effect:

**no traps are deployed or updated anymore** - every reconcile of every `DeceptionPolicy` runs `cleanupRemovedTraps` first and returns early on the error

**policies cannot be deleted** - `cleanupDeceptionPolicy` fails the same way, the finalizer is never removed and the object stays in `Terminating` forever

the annotation is koney bookkeeping rather than a user-facing API, and closed issue #12 already treats annotation-parsing brittleness as a bug, so failing closed on someone else's broken value looks unintended

this logs and skips resources whose annotation cannot be read, which also lets the clean-up path finish and release the finalizer. added tests for a valid resource, a broken one next to a valid one, and a lone broken one
