### PR TITLE
fix: keep the honeytoken secret when other deployments still mount it

### DIFF
--- a/internal/controller/traps/filesystoken/removal.go
+++ b/internal/controller/traps/filesystoken/removal.go
@@ -213,12 +213,8 @@ func (r *FilesystemHoneytokenReconciler) removeDecoyWithVolumeMount(ctx context.
 		log.Info("FilesystemHoneytoken trap removed from container", "container", containerName)
 	}
 
-	// Delete the secret, if it was created by the trap.
-	// The secret is named after the file path and content only, so the very same secret can be
-	// mounted by other deployments that match the trap. Kubernetes does not stop us from deleting
-	// a secret that is still in use, their pods would just fail to start on the next restart,
-	// so we have to check the remaining deployments ourselves. We also keep the secret when the
-	// update above failed, because then this deployment still mounts it.
+	// Before deleting the secret, we should check for other mounters because the secret
+	// could be shared and in-use by other deployments with matching trap content.
 	if secretName != "" && err == nil {
 		stillMounted, mountErr := r.isSecretStillMounted(ctx, deployment.Namespace, secretName, deployment.Name)
 		if mountErr != nil {

--- a/internal/controller/traps/filesystoken/removal.go
+++ b/internal/controller/traps/filesystoken/removal.go
@@ -193,7 +193,9 @@ func (r *FilesystemHoneytokenReconciler) removeDecoyWithVolumeMount(ctx context.
 		if volume.Name != volumeName {
 			newVolumes = append(newVolumes, deployment.Spec.Template.Spec.Volumes[i])
 		} else {
-			secretName = volume.Secret.SecretName
+			if volume.Secret != nil {
+				secretName = volume.Secret.SecretName
+			}
 			log.Info("Removing volume from deployment", "volume", volumeName)
 		}
 	}
@@ -211,18 +213,53 @@ func (r *FilesystemHoneytokenReconciler) removeDecoyWithVolumeMount(ctx context.
 		log.Info("FilesystemHoneytoken trap removed from container", "container", containerName)
 	}
 
-	// Delete the secret, if it was created by the trap
-	if secretName != "" {
-		secret := corev1.Secret{}
-		err = r.Get(ctx, client.ObjectKey{Namespace: deployment.Namespace, Name: secretName}, &secret)
-		if err != nil {
-			log.Error(err, "unable to get secret", "secret", secretName)
-			joinedErrors = errors.Join(joinedErrors, err)
+	// Delete the secret, if it was created by the trap.
+	// The secret is named after the file path and content only, so the very same secret can be
+	// mounted by other deployments that match the trap. Kubernetes does not stop us from deleting
+	// a secret that is still in use, their pods would just fail to start on the next restart,
+	// so we have to check the remaining deployments ourselves. We also keep the secret when the
+	// update above failed, because then this deployment still mounts it.
+	if secretName != "" && err == nil {
+		stillMounted, mountErr := r.isSecretStillMounted(ctx, deployment.Namespace, secretName, deployment.Name)
+		if mountErr != nil {
+			log.Error(mountErr, "unable to check whether the secret is still in use", "secret", secretName)
+			joinedErrors = errors.Join(joinedErrors, mountErr)
+		} else if stillMounted {
+			log.Info("Keeping secret because it is still mounted by another deployment", "secret", secretName)
 		} else {
-			// This might fail if the secret is still being used by another pod, we ignore the error
-			_ = r.Delete(ctx, &secret)
+			secret := corev1.Secret{}
+			err = r.Get(ctx, client.ObjectKey{Namespace: deployment.Namespace, Name: secretName}, &secret)
+			if err != nil {
+				log.Error(err, "unable to get secret", "secret", secretName)
+				joinedErrors = errors.Join(joinedErrors, err)
+			} else {
+				_ = r.Delete(ctx, &secret)
+			}
 		}
 	}
 
 	return joinedErrors
+}
+
+// isSecretStillMounted reports whether any deployment in the namespace, other than the one we
+// just updated, still mounts the given secret.
+func (r *FilesystemHoneytokenReconciler) isSecretStillMounted(ctx context.Context, namespace string, secretName string, excludedDeployment string) (bool, error) {
+	deployments := &appsv1.DeploymentList{}
+	if err := r.List(ctx, deployments, client.InNamespace(namespace)); err != nil {
+		return false, err
+	}
+
+	for _, deployment := range deployments.Items {
+		if deployment.Name == excludedDeployment {
+			continue
+		}
+
+		for _, volume := range deployment.Spec.Template.Spec.Volumes {
+			if volume.Secret != nil && volume.Secret.SecretName == secretName {
+				return true, nil
+			}
+		}
+	}
+
+	return false, nil
 }

--- a/internal/controller/traps/filesystoken/removal_secret_test.go
+++ b/internal/controller/traps/filesystoken/removal_secret_test.go
@@ -1,0 +1,130 @@
+// Copyright (c) 2025 Dynatrace LLC
+//
+// This program is free software: you can redistribute it and/or modify
+// it under the terms of the GNU Affero General Public License as published by
+// the Free Software Foundation, either version 3 of the License, or
+// (at your option) any later version.
+//
+// This program is distributed in the hope that it will be useful,
+// but WITHOUT ANY WARRANTY; without even the implied warranty of
+// MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+// GNU Affero General Public License for more details.
+//
+// You should have received a copy of the GNU Affero General Public License
+// along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+package filesystoken
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	appsv1 "k8s.io/api/apps/v1"
+	corev1 "k8s.io/api/core/v1"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	clientgoscheme "k8s.io/client-go/kubernetes/scheme"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+
+	"github.com/dynatrace-oss/koney/api/v1alpha1"
+)
+
+const (
+	secretTestNamespace  = "test-namespace"
+	secretTestFilePath   = "/run/secrets/koney/service_token"
+	secretTestSecretName = "koney-secret-test"
+)
+
+// newSecretTestReconciler returns a reconciler backed by a fake client that knows the given objects.
+func newSecretTestReconciler(objects ...client.Object) *FilesystemHoneytokenReconciler {
+	scheme := runtime.NewScheme()
+	Expect(clientgoscheme.AddToScheme(scheme)).To(Succeed())
+	Expect(v1alpha1.AddToScheme(scheme)).To(Succeed())
+
+	fakeClient := fake.NewClientBuilder().WithScheme(scheme).WithObjects(objects...).Build()
+	return &FilesystemHoneytokenReconciler{Client: fakeClient, Scheme: scheme}
+}
+
+// newDeploymentMountingHoneytoken returns a deployment that mounts the honeytoken secret in one container.
+func newDeploymentMountingHoneytoken(name string) *appsv1.Deployment {
+	volumeName := generateVolumeName(secretTestFilePath)
+
+	return &appsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: secretTestNamespace},
+		Spec: appsv1.DeploymentSpec{
+			Template: corev1.PodTemplateSpec{
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{{
+						Name:         "app",
+						VolumeMounts: []corev1.VolumeMount{{Name: volumeName, MountPath: secretTestFilePath}},
+					}},
+					Volumes: []corev1.Volume{{
+						Name:         volumeName,
+						VolumeSource: corev1.VolumeSource{Secret: &corev1.SecretVolumeSource{SecretName: secretTestSecretName}},
+					}},
+				},
+			},
+		},
+	}
+}
+
+func newHoneytokenSecret(name string) *corev1.Secret {
+	return &corev1.Secret{ObjectMeta: metav1.ObjectMeta{Name: name, Namespace: secretTestNamespace}}
+}
+
+func newVolumeMountTrapAnnotation() v1alpha1.TrapAnnotation {
+	return v1alpha1.TrapAnnotation{
+		DeploymentStrategy:   "volumeMount",
+		Containers:           []string{"app"},
+		FilesystemHoneytoken: v1alpha1.FilesystemHoneytokenAnnotation{FilePath: secretTestFilePath},
+	}
+}
+
+// honeytokenSecretExists reports whether the secret is still present in the fake cluster.
+func honeytokenSecretExists(r *FilesystemHoneytokenReconciler, name string) bool {
+	secret := corev1.Secret{}
+	err := r.Get(context.Background(), client.ObjectKey{Namespace: secretTestNamespace, Name: name}, &secret)
+	if apierrors.IsNotFound(err) {
+		return false
+	}
+
+	Expect(err).ShouldNot(HaveOccurred())
+	return true
+}
+
+var _ = Describe("RemoveDecoy with the volumeMount strategy", func() {
+	Context("when no other deployment mounts the honeytoken secret", func() {
+		It("should delete the secret", func() {
+			deployment := newDeploymentMountingHoneytoken("web")
+			r := newSecretTestReconciler(deployment, newHoneytokenSecret(secretTestSecretName))
+
+			Expect(r.RemoveDecoy(context.Background(), "policy-a", newVolumeMountTrapAnnotation(), deployment)).To(Succeed())
+			Expect(honeytokenSecretExists(r, secretTestSecretName)).Should(BeFalse())
+		})
+	})
+
+	Context("when another deployment still mounts the same honeytoken secret", func() {
+		It("should keep the secret", func() {
+			deployment := newDeploymentMountingHoneytoken("web")
+			other := newDeploymentMountingHoneytoken("api")
+			r := newSecretTestReconciler(deployment, other, newHoneytokenSecret(secretTestSecretName))
+
+			Expect(r.RemoveDecoy(context.Background(), "policy-a", newVolumeMountTrapAnnotation(), deployment)).To(Succeed())
+			Expect(honeytokenSecretExists(r, secretTestSecretName)).Should(BeTrue())
+		})
+	})
+
+	Context("when the deployment cannot be updated", func() {
+		It("should keep the secret that the deployment still mounts", func() {
+			// The deployment is not in the cluster, so the update fails and the volume is never removed
+			deployment := newDeploymentMountingHoneytoken("web")
+			r := newSecretTestReconciler(newHoneytokenSecret(secretTestSecretName))
+
+			Expect(r.RemoveDecoy(context.Background(), "policy-a", newVolumeMountTrapAnnotation(), deployment)).ShouldNot(Succeed())
+			Expect(honeytokenSecretExists(r, secretTestSecretName)).Should(BeTrue())
+		})
+	})
+})


### PR DESCRIPTION
## Summary

`removeDecoyWithVolumeMount` deletes the honeytoken secret unconditionally, and the comment explains it away with a guarantee that does not exist:

```go
// This might fail if the secret is still being used by another pod, we ignore the error
_ = r.Delete(ctx, &secret)
```

the API server does not block deleting a secret that is still mounted, the pods simply fail to start the next time they are scheduled

that matters because the secret is not scoped to a policy or a workload. `generateSecretName` hashes only `filePath + ":" + fileContent`, so every deployment in a namespace that matches the trap mounts the very same secret, and two `DeceptionPolicy` objects with identical path and content share it too

so narrowing one policy, or removing a trap from one deployment, deletes a secret that other deployments still reference. they keep running on the mounted copy until the first restart and then sit in `ContainerCreating` with `secret not found`, while their honeytoken quietly disappears

this checks the remaining deployments in the namespace before deleting. the secret is also kept when the deployment update failed, because then this deployment still mounts it, and `volume.Secret` is now guarded against nil. added tests for the sole-user, shared-user and failed-update cases
