### PR TITLE
fix: honor matchExpressions in resource selectors

### DIFF
--- a/README.md
+++ b/README.md
@@ -153,7 +153,7 @@ The `any` field is a list and holds one or more `resources` objects, which conta
 - `namespaces`: a list of namespaces. It does NOT support wildcards. The trap is only deployed in pods that belong to any of the namespaces in the list.
 - `selector`: a label selector. It does NOT support wildcards. The trap is only deployed in pods with labels that match the selector. If you specify multiple labels or expressions, all of them have to match for traps to be deployed. `selector` has two fields:
   - `matchLabels`: a map of key-value pairs.
-  - `matchExpressions`: a list of label selector requirements evaluated as a logical AND operation. **(not implemented yet)**
+  - `matchExpressions`: a list of label selector requirements evaluated as a logical AND operation. Decoys are deployed to the matching pods and deployments, and captors deployed with the `tetragon` strategy watch them. Not supported with the `kive` captor deployment strategy: Kive captors do not watch the pods selected by a resource filter that uses `matchExpressions`, and the `DeceptionPolicy` reports this in its status with the `UnsupportedSelectors` reason
 
 - `containerSelector`: selects the container(s) in the matched pods or deployments where the trap is deployed.
   - if this field is prepended by `regex:`, the rest of the string will represent a regular expression matched with go [regexp](https://golang.org/s/re2syntax) library. The pattern is searched inside the container name (i.e., a partial match also counts), so a pattern like `regex:app` matches any container whose name contains `app`. Use `^` and `$` anchors to enforce exact boundaries (e.g., `regex:^app$` matches only a container named exactly `app`).

--- a/api/v1alpha1/dp_trap_types.go
+++ b/api/v1alpha1/dp_trap_types.go
@@ -94,7 +94,10 @@ func (trap *Trap) IsValid() error {
 			return errors.New("MatchResources.Any.Namespaces and MatchResources.Any.Selector are nil")
 		}
 
-		if len(value.Namespaces) == 0 && (value.Selector == nil || len(value.Selector.MatchLabels) == 0) {
+		selectorIsEmpty := value.Selector == nil ||
+			(len(value.Selector.MatchLabels) == 0 && len(value.Selector.MatchExpressions) == 0)
+
+		if len(value.Namespaces) == 0 && selectorIsEmpty {
 			return errors.New("MatchResources.Any.Namespaces and MatchResources.Any.Selector are empty")
 		}
 

--- a/api/v1alpha1/dp_trap_types_test.go
+++ b/api/v1alpha1/dp_trap_types_test.go
@@ -174,6 +174,32 @@ var _ = Describe("IsValid", func() {
 		})
 	})
 
+	Context("when checking a trap with a selector that only has MatchExpressions", func() {
+		It("should return no error", func() {
+			for _, trap := range testTraps {
+				trap.MatchResources = MatchResources{
+					Any: []ResourceFilter{
+						{
+							ResourceDescription: ResourceDescription{
+								Selector: &metav1.LabelSelector{
+									MatchExpressions: []metav1.LabelSelectorRequirement{
+										{
+											Key:      "deceptionpolicies.research.dynatrace.com/label",
+											Operator: metav1.LabelSelectorOpExists,
+										},
+									},
+								},
+								Namespaces: []string{},
+							},
+						},
+					},
+				}
+				err := trap.IsValid()
+				Expect(err).ShouldNot(HaveOccurred())
+			}
+		})
+	})
+
 	Context("when checking a filesystem honeytoken trap with a non-absolute file path", func() {
 		It("should return error", func() {
 			for _, trap := range testTraps {

--- a/internal/controller/deceptionpolicy_trap_deployment.go
+++ b/internal/controller/deceptionpolicy_trap_deployment.go
@@ -141,6 +141,10 @@ func (r *DeceptionPolicyReconciler) reconcileCaptors(ctx context.Context, decept
 			reconcileResult.OverrideStatusConditionReason = CaptorsDeployedReason_MissingTetragon
 			reconcileResult.OverrideStatusConditionMessage = CaptorsDeployedMessage_MissingTetragon
 		}
+		if result.UnsupportedSelectors {
+			reconcileResult.OverrideStatusConditionReason = CaptorsDeployedReason_UnsupportedSelectors
+			reconcileResult.OverrideStatusConditionMessage = CaptorsDeployedMessage_UnsupportedSelectors
+		}
 		if result.ImpliesRetry() {
 			log.Info("Encountered resources that are not yet ready for captors - will retry soon", "trap", result.GetTrap())
 			reconcileResult.ShouldRequeue = true

--- a/internal/controller/matching/matching.go
+++ b/internal/controller/matching/matching.go
@@ -156,6 +156,9 @@ func getMatchingObjectsByNamespaceAndLabels(r client.Reader, ctx context.Context
 	matchingByNamespace := []client.Object{} // The objects that match the namespaces for this ResourceFilter
 	matchingByLabels := []client.Object{}    // The objects that match the labels for this ResourceFilter
 
+	selectorIsEmpty := resourceFilter.Selector == nil ||
+		(len(resourceFilter.Selector.MatchLabels) == 0 && len(resourceFilter.Selector.MatchExpressions) == 0)
+
 	if len(resourceFilter.Namespaces) > 0 {
 		// Get the objects that match one of the namespaces
 		for _, namespace := range resourceFilter.Namespaces {
@@ -172,10 +175,15 @@ func getMatchingObjectsByNamespaceAndLabels(r client.Reader, ctx context.Context
 		}
 	}
 
-	if resourceFilter.Selector != nil && len(resourceFilter.Selector.MatchLabels) > 0 {
+	if !selectorIsEmpty {
 		// Get the objects that match the labels
+		selector, err := metav1.LabelSelectorAsSelector(resourceFilter.Selector)
+		if err != nil {
+			return nil, err
+		}
+
 		items := []client.Object{}
-		if err := listItemsAsObjects(r, ctx, &items, makeList(), client.MatchingLabels(resourceFilter.Selector.MatchLabels)); err != nil {
+		if err := listItemsAsObjects(r, ctx, &items, makeList(), client.MatchingLabelsSelector{Selector: selector}); err != nil {
 			return nil, err
 		} else {
 			for _, object := range items {
@@ -196,7 +204,7 @@ func getMatchingObjectsByNamespaceAndLabels(r client.Reader, ctx context.Context
 	}
 
 	// If no labels are specified, add all the objects that match the namespaces
-	if resourceFilter.Selector == nil || len(resourceFilter.Selector.MatchLabels) == 0 {
+	if selectorIsEmpty {
 		for _, object := range matchingByNamespace {
 			if !utils.Contains(extractObjectKeys(matchingObjects), client.ObjectKeyFromObject(object)) {
 				matchingObjects = append(matchingObjects, object)

--- a/internal/controller/matching/matching_test.go
+++ b/internal/controller/matching/matching_test.go
@@ -1171,6 +1171,65 @@ var _ = Describe("getMatchingPodsWithContainers", func() {
 				koneyPodWithLabelC.Name, koneyPodWithLabelABC.Name,
 				otherPodWithLabelC.Name, otherPodWithoutLabels.Name))
 		})
+
+		It("should match a matchExpressions selector", func() {
+			match := v1alpha1.MatchResources{
+				Any: []v1alpha1.ResourceFilter{
+					{
+						ResourceDescription: v1alpha1.ResourceDescription{
+							Selector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      KoneyLabelAKey,
+										Operator: metav1.LabelSelectorOpExists,
+									},
+								},
+							},
+						},
+					},
+				},
+			}
+
+			matchingPodsWithContainers, err := getMatchingPodsWithContainers(client, ctx, match)
+			Expect(err).ToNot(HaveOccurred())
+
+			matchingPods := utils.GetMapKeys(matchingPodsWithContainers)
+
+			matchingPodNames := extractObjectNames(matchingPods)
+			Expect(matchingPodNames).To(HaveLen(3))
+			Expect(matchingPodNames).To(ConsistOf(
+				koneyPodWithLabelA.Name, koneyPodWithLabelAB.Name, koneyPodWithLabelABC.Name))
+		})
+
+		It("should match a matchExpressions selector and namespace (expect logical and)", func() {
+			match := v1alpha1.MatchResources{
+				Any: []v1alpha1.ResourceFilter{
+					{
+						ResourceDescription: v1alpha1.ResourceDescription{
+							Selector: &metav1.LabelSelector{
+								MatchExpressions: []metav1.LabelSelectorRequirement{
+									{
+										Key:      KoneyLabelAKey,
+										Operator: metav1.LabelSelectorOpExists,
+									},
+								},
+							},
+							Namespaces: []string{KoneyNamespace},
+						},
+					},
+				},
+			}
+
+			matchingPodsWithContainers, err := getMatchingPodsWithContainers(client, ctx, match)
+			Expect(err).ToNot(HaveOccurred())
+
+			matchingPods := utils.GetMapKeys(matchingPodsWithContainers)
+
+			matchingPodNames := extractObjectNames(matchingPods)
+			Expect(matchingPodNames).To(HaveLen(3))
+			Expect(matchingPodNames).To(ConsistOf(
+				koneyPodWithLabelA.Name, koneyPodWithLabelAB.Name, koneyPodWithLabelABC.Name))
+		})
 	})
 })
 

--- a/internal/controller/matching/matching_test.go
+++ b/internal/controller/matching/matching_test.go
@@ -1202,6 +1202,22 @@ var _ = Describe("getMatchingPodsWithContainers", func() {
 		})
 
 		It("should match a matchExpressions selector and namespace (expect logical and)", func() {
+			// A pod with the same label in another namespace must not be matched
+			otherPodWithLabelA := corev1.Pod{
+				ObjectMeta: metav1.ObjectMeta{
+					Name:      "other-pod-with-label-a",
+					Namespace: OtherNamespace,
+					Labels: map[string]string{
+						KoneyLabelAKey: KoneyLabelAValue,
+					},
+				},
+				Status: koneyPodWithLabelA.Status,
+				Spec:   corev1.PodSpec{Containers: []corev1.Container{{Name: "foo"}}},
+			}
+			podsWithOtherLabelA := podList.DeepCopy()
+			podsWithOtherLabelA.Items = append(podsWithOtherLabelA.Items, otherPodWithLabelA)
+			client = fake.NewClientBuilder().WithLists(podsWithOtherLabelA).Build()
+
 			match := v1alpha1.MatchResources{
 				Any: []v1alpha1.ResourceFilter{
 					{

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -46,14 +46,16 @@ const (
 
 	TrapDeployedMessage_NoObjects = "No objects matching selection criteria"
 
-	CaptorsDeployedReason_Pending         = "CaptorDeploymentPending"
-	CaptorsDeployedReason_Success         = "CaptorDeploymentSucceeded"
-	CaptorsDeployedReason_PartialSuccess  = "CaptorDeploymentSucceededPartially"
-	CaptorsDeployedReason_GenericError    = "CaptorDeploymentError"
-	CaptorsDeployedReason_NoObjects       = "NoObjectsMatched"
-	CaptorsDeployedReason_MissingTetragon = "TetragonNotInstalled"
+	CaptorsDeployedReason_Pending              = "CaptorDeploymentPending"
+	CaptorsDeployedReason_Success              = "CaptorDeploymentSucceeded"
+	CaptorsDeployedReason_PartialSuccess       = "CaptorDeploymentSucceededPartially"
+	CaptorsDeployedReason_GenericError         = "CaptorDeploymentError"
+	CaptorsDeployedReason_NoObjects            = "NoObjectsMatched"
+	CaptorsDeployedReason_MissingTetragon      = "TetragonNotInstalled"
+	CaptorsDeployedReason_UnsupportedSelectors = "UnsupportedSelectors"
 
-	CaptorsDeployedMessage_MissingTetragon = "Cannot deploy captors without Tetragon"
+	CaptorsDeployedMessage_MissingTetragon      = "Cannot deploy captors without Tetragon"
+	CaptorsDeployedMessage_UnsupportedSelectors = "Captors do not watch all selected resources, because Kive cannot evaluate selector.matchExpressions"
 )
 
 // TrapDeploymentStatusEnum defines the possible conditions for a trap deployment.

--- a/internal/controller/status.go
+++ b/internal/controller/status.go
@@ -55,7 +55,7 @@ const (
 	CaptorsDeployedReason_UnsupportedSelectors = "UnsupportedSelectors"
 
 	CaptorsDeployedMessage_MissingTetragon      = "Cannot deploy captors without Tetragon"
-	CaptorsDeployedMessage_UnsupportedSelectors = "Captors do not watch all selected resources, because Kive cannot evaluate selector.matchExpressions"
+	CaptorsDeployedMessage_UnsupportedSelectors = "selector.matchExpressions is not supported with Kive"
 )
 
 // TrapDeploymentStatusEnum defines the possible conditions for a trap deployment.

--- a/internal/controller/traps/api/result_types.go
+++ b/internal/controller/traps/api/result_types.go
@@ -72,8 +72,8 @@ type CaptorDeploymentResult struct {
 	Errors error
 	// MissingTetragon is set if we saw indications that Tetragon is not available in the cluster.
 	MissingTetragon bool
-	// UnsupportedSelectors is set if the captor cannot watch all resources that the trap selects,
-	// because the deployment strategy cannot express the selectors of the trap.
+	// UnsupportedSelectors is set alongside Errors when the captor cannot watch all resources
+	// that the trap selects, so the status can show a specific reason.
 	UnsupportedSelectors bool
 }
 
@@ -86,11 +86,11 @@ func (result CaptorDeploymentResult) GetErrors() error {
 }
 
 func (result CaptorDeploymentResult) ImpliesSuccess() bool {
-	return result.Errors == nil && !result.UnsupportedSelectors
+	return result.Errors == nil
 }
 
 func (result CaptorDeploymentResult) ImpliesFailure() bool {
-	return result.Errors != nil || result.MissingTetragon || result.UnsupportedSelectors
+	return result.Errors != nil || result.MissingTetragon
 }
 
 func (result CaptorDeploymentResult) ImpliesRetry() bool {

--- a/internal/controller/traps/api/result_types.go
+++ b/internal/controller/traps/api/result_types.go
@@ -72,6 +72,9 @@ type CaptorDeploymentResult struct {
 	Errors error
 	// MissingTetragon is set if we saw indications that Tetragon is not available in the cluster.
 	MissingTetragon bool
+	// UnsupportedSelectors is set if the captor cannot watch all resources that the trap selects,
+	// because the deployment strategy cannot express the selectors of the trap.
+	UnsupportedSelectors bool
 }
 
 func (result CaptorDeploymentResult) GetTrap() *v1alpha1.Trap {
@@ -83,11 +86,11 @@ func (result CaptorDeploymentResult) GetErrors() error {
 }
 
 func (result CaptorDeploymentResult) ImpliesSuccess() bool {
-	return result.Errors == nil
+	return result.Errors == nil && !result.UnsupportedSelectors
 }
 
 func (result CaptorDeploymentResult) ImpliesFailure() bool {
-	return result.Errors != nil || result.MissingTetragon
+	return result.Errors != nil || result.MissingTetragon || result.UnsupportedSelectors
 }
 
 func (result CaptorDeploymentResult) ImpliesRetry() bool {

--- a/internal/controller/traps/filesystoken/deployment.go
+++ b/internal/controller/traps/filesystoken/deployment.go
@@ -432,7 +432,7 @@ func (r *FilesystemHoneytokenReconciler) deployCaptorWithKive(ctx context.Contex
 		return err
 	}
 
-	tracingPolicy := generateKivePolicy(deceptionPolicy, trap, tracingPolicyName)
+	tracingPolicy := generateKivePolicy(ctx, deceptionPolicy, trap, tracingPolicyName)
 	if err != nil {
 		log.Error(err, "unable to generate Kive tracing policy")
 		return err

--- a/internal/controller/traps/filesystoken/deployment.go
+++ b/internal/controller/traps/filesystoken/deployment.go
@@ -179,6 +179,10 @@ func (r *FilesystemHoneytokenReconciler) DeployDecoy(ctx context.Context, decept
 		Errors:                      joinedErrors}
 }
 
+// ErrKiveUnsupportedSelectors is returned when a trap selects resources with selector.matchExpressions,
+// which Kive cannot evaluate, so its captors do not watch all selected resources.
+var ErrKiveUnsupportedSelectors = errors.New("selector.matchExpressions is not supported with Kive")
+
 // DeployCaptor deploys a captor for a filesystem honeytoken trap.
 func (r *FilesystemHoneytokenReconciler) DeployCaptor(ctx context.Context, deceptionPolicy *v1alpha1.DeceptionPolicy, trap v1alpha1.Trap) trapsapi.CaptorDeploymentResult {
 	log := k8slog.FromContext(ctx)
@@ -201,9 +205,8 @@ func (r *FilesystemHoneytokenReconciler) DeployCaptor(ctx context.Context, decep
 			return trapsapi.CaptorDeploymentResult{Trap: &trap, Errors: err, MissingTetragon: missingKive}
 		}
 		if trapUsesMatchExpressions(trap) {
-			// The policy was applied, but it does not watch the resources that were selected
-			// with matchExpressions, so the trap is only partially covered by captors.
-			return trapsapi.CaptorDeploymentResult{Trap: &trap, UnsupportedSelectors: true}
+			log.Error(ErrKiveUnsupportedSelectors, "captors do not watch all selected resources")
+			return trapsapi.CaptorDeploymentResult{Trap: &trap, Errors: ErrKiveUnsupportedSelectors, UnsupportedSelectors: true}
 		}
 	case "none":
 		log.Info("Captor deployment strategy is 'none' - skipping captor deployment")

--- a/internal/controller/traps/filesystoken/deployment.go
+++ b/internal/controller/traps/filesystoken/deployment.go
@@ -200,6 +200,11 @@ func (r *FilesystemHoneytokenReconciler) DeployCaptor(ctx context.Context, decep
 			}
 			return trapsapi.CaptorDeploymentResult{Trap: &trap, Errors: err, MissingTetragon: missingKive}
 		}
+		if trapUsesMatchExpressions(trap) {
+			// The policy was applied, but it does not watch the resources that were selected
+			// with matchExpressions, so the trap is only partially covered by captors.
+			return trapsapi.CaptorDeploymentResult{Trap: &trap, UnsupportedSelectors: true}
+		}
 	case "none":
 		log.Info("Captor deployment strategy is 'none' - skipping captor deployment")
 		return trapsapi.CaptorDeploymentResult{Trap: &trap}
@@ -408,7 +413,7 @@ func (r *FilesystemHoneytokenReconciler) deployCaptorWithTetragon(ctx context.Co
 			return err
 		}
 
-		tracingPolicy := generateTetragonTracingPolicy(deceptionPolicy, trap, tracingPolicyName)
+		tracingPolicy := generateTetragonTracingPolicy(ctx, deceptionPolicy, trap, tracingPolicyName)
 
 		if err := r.Create(ctx, tracingPolicy); err != nil {
 			log.Error(err, "unable to create Tetragon tracing policy")

--- a/internal/controller/traps/filesystoken/utils.go
+++ b/internal/controller/traps/filesystoken/utils.go
@@ -108,8 +108,9 @@ func generateVolumeName(filePath string) string {
 }
 
 // generateTetragonTracingPolicy generates a Tetragon tracing policy for a filesystem honeytoken trap.
-func generateTetragonTracingPolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
+func generateTetragonTracingPolicy(ctx context.Context, deceptionPolicy *v1alpha1.DeceptionPolicy,
 	trap v1alpha1.Trap, tracingPolicyName string) *ciliumiov1alpha1.TracingPolicy {
+	log := k8slog.FromContext(ctx)
 	/*
 		The `security_file_permission` function is a common execution point for the execution of
 		system calls related to filesystem access, such as read, write, etc.
@@ -227,7 +228,15 @@ func generateTetragonTracingPolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
 		},
 	}
 
-	// Add the labels and expressions from the trap's MatchResources to the PodSelector
+	// Add the labels and expressions from the trap's MatchResources to the PodSelector.
+	// A TracingPolicy has a single PodSelector, but resource filters are matched with a
+	// logical OR, so filters that carry selectors cannot be translated without losing precision.
+	if countResourceFiltersWithSelector(trap) > 1 {
+		log.Info("WARNING: multiple resource filters have a selector, but a Tetragon tracing policy has only one podSelector, "+
+			"so all selectors are merged and combined with a logical AND, which matches fewer pods than the trap selects",
+			"policy", deceptionPolicy.Name, "filePath", trap.FilesystemHoneytoken.FilePath)
+	}
+
 	for _, resourceFilter := range trap.MatchResources.Any {
 		if resourceFilter.Selector == nil {
 			continue
@@ -368,7 +377,7 @@ func generateKivePolicy(ctx context.Context, deceptionPolicy *v1alpha1.Deception
 		// Kive can only match on plain labels. Generating a match for a selector that also
 		// carries expressions would silently widen the scope of the trap, so we skip it.
 		if resourceFilterUsesMatchExpressions(resource) {
-			log.Info("skipping resource filter in Kive policy, because Kive does not support selector.matchExpressions",
+			log.Error(nil, "Kive does not support selector.matchExpressions - skipping resource filter, no captor will watch the matched resources",
 				"policy", deceptionPolicy.Name, "filePath", trap.FilesystemHoneytoken.FilePath)
 			continue
 		}
@@ -424,4 +433,28 @@ func selectorMatchLabels(resource v1alpha1.ResourceFilter) map[string]string {
 // resourceFilterUsesMatchExpressions returns true if a resource filter uses selector.matchExpressions.
 func resourceFilterUsesMatchExpressions(resource v1alpha1.ResourceFilter) bool {
 	return resource.Selector != nil && len(resource.Selector.MatchExpressions) > 0
+}
+
+// trapUsesMatchExpressions returns true if any resource filter of a trap uses selector.matchExpressions.
+func trapUsesMatchExpressions(trap v1alpha1.Trap) bool {
+	for _, resource := range trap.MatchResources.Any {
+		if resourceFilterUsesMatchExpressions(resource) {
+			return true
+		}
+	}
+	return false
+}
+
+// countResourceFiltersWithSelector returns the number of resource filters of a trap that have a non-empty selector.
+func countResourceFiltersWithSelector(trap v1alpha1.Trap) int {
+	count := 0
+	for _, resource := range trap.MatchResources.Any {
+		if resource.Selector == nil {
+			continue
+		}
+		if len(resource.Selector.MatchLabels) > 0 || len(resource.Selector.MatchExpressions) > 0 {
+			count++
+		}
+	}
+	return count
 }

--- a/internal/controller/traps/filesystoken/utils.go
+++ b/internal/controller/traps/filesystoken/utils.go
@@ -228,23 +228,14 @@ func generateTetragonTracingPolicy(ctx context.Context, deceptionPolicy *v1alpha
 		},
 	}
 
-	// Add the labels and expressions from the trap's MatchResources to the PodSelector.
-	// A TracingPolicy has a single PodSelector, but resource filters are matched with a
-	// logical OR, so filters that carry selectors cannot be translated without losing precision.
-	if countResourceFiltersWithSelector(trap) > 1 {
-		log.Info("WARNING: multiple resource filters have a selector, but a Tetragon tracing policy has only one podSelector, "+
-			"so all selectors are merged and combined with a logical AND, which matches fewer pods than the trap selects",
-			"policy", deceptionPolicy.Name, "filePath", trap.FilesystemHoneytoken.FilePath)
-	}
-
-	for _, resourceFilter := range trap.MatchResources.Any {
-		if resourceFilter.Selector == nil {
-			continue
-		}
-		for key, value := range resourceFilter.Selector.MatchLabels {
+	// Resource filters are OR'd, but a TracingPolicy has a single PodSelector. With more than
+	// one filter we leave it empty and watch a superset instead of missing pods.
+	filters := trap.MatchResources.Any
+	if len(filters) == 1 && filters[0].Selector != nil {
+		for key, value := range filters[0].Selector.MatchLabels {
 			tracingPolicy.Spec.PodSelector.MatchLabels[key] = value
 		}
-		for _, requirement := range resourceFilter.Selector.MatchExpressions {
+		for _, requirement := range filters[0].Selector.MatchExpressions {
 			tracingPolicy.Spec.PodSelector.MatchExpressions = append(
 				tracingPolicy.Spec.PodSelector.MatchExpressions,
 				slimv1.LabelSelectorRequirement{
@@ -254,6 +245,10 @@ func generateTetragonTracingPolicy(ctx context.Context, deceptionPolicy *v1alpha
 				},
 			)
 		}
+	} else if countResourceFiltersWithSelector(trap) > 0 {
+		log.Info("WARNING: the trap has multiple resource filters, but a Tetragon tracing policy has only one podSelector, "+
+			"so the podSelector is left empty and the captor may watch more pods than the trap selects",
+			"policy", deceptionPolicy.Name, "filePath", trap.FilesystemHoneytoken.FilePath)
 	}
 
 	// Determine how to populate the ContainerSelector:
@@ -417,8 +412,6 @@ func generateKivePolicy(ctx context.Context, deceptionPolicy *v1alpha1.Deception
 	return tracingPolicy
 }
 
-// selectorMatchLabels returns a copy of the match labels of a resource filter,
-// or an empty map if the resource filter has no selector.
 func selectorMatchLabels(resource v1alpha1.ResourceFilter) map[string]string {
 	matchLabels := map[string]string{}
 	if resource.Selector == nil {
@@ -430,12 +423,10 @@ func selectorMatchLabels(resource v1alpha1.ResourceFilter) map[string]string {
 	return matchLabels
 }
 
-// resourceFilterUsesMatchExpressions returns true if a resource filter uses selector.matchExpressions.
 func resourceFilterUsesMatchExpressions(resource v1alpha1.ResourceFilter) bool {
 	return resource.Selector != nil && len(resource.Selector.MatchExpressions) > 0
 }
 
-// trapUsesMatchExpressions returns true if any resource filter of a trap uses selector.matchExpressions.
 func trapUsesMatchExpressions(trap v1alpha1.Trap) bool {
 	for _, resource := range trap.MatchResources.Any {
 		if resourceFilterUsesMatchExpressions(resource) {
@@ -445,7 +436,6 @@ func trapUsesMatchExpressions(trap v1alpha1.Trap) bool {
 	return false
 }
 
-// countResourceFiltersWithSelector returns the number of resource filters of a trap that have a non-empty selector.
 func countResourceFiltersWithSelector(trap v1alpha1.Trap) int {
 	count := 0
 	for _, resource := range trap.MatchResources.Any {

--- a/internal/controller/traps/filesystoken/utils.go
+++ b/internal/controller/traps/filesystoken/utils.go
@@ -367,7 +367,7 @@ func generateKivePolicy(ctx context.Context, deceptionPolicy *v1alpha1.Deception
 
 		// Kive can only match on plain labels. Generating a match for a selector that also
 		// carries expressions would silently widen the scope of the trap, so we skip it.
-		if resource.Selector != nil && len(resource.Selector.MatchExpressions) > 0 {
+		if resourceFilterUsesMatchExpressions(resource) {
 			log.Info("skipping resource filter in Kive policy, because Kive does not support selector.matchExpressions",
 				"policy", deceptionPolicy.Name, "filePath", trap.FilesystemHoneytoken.FilePath)
 			continue
@@ -380,16 +380,7 @@ func generateKivePolicy(ctx context.Context, deceptionPolicy *v1alpha1.Deception
 		if len(resource.Namespaces) == 0 {
 			kiveTrapMatch := kivev1.KiveTrapMatch{
 				ContainerName: resource.ContainerSelector,
-				MatchLabels:   map[string]string{},
-			}
-
-			for _, resourceFilter := range trap.MatchResources.Any {
-				if resourceFilter.Selector == nil {
-					continue
-				}
-				for key, value := range resourceFilter.Selector.MatchLabels {
-					kiveTrapMatch.MatchLabels[key] = value
-				}
+				MatchLabels:   selectorMatchLabels(resource),
 			}
 
 			kiveTrapMatches = append(kiveTrapMatches, kiveTrapMatch)
@@ -401,16 +392,7 @@ func generateKivePolicy(ctx context.Context, deceptionPolicy *v1alpha1.Deception
 				kiveTrapMatch := kivev1.KiveTrapMatch{
 					Namespace:     namespace,
 					ContainerName: resource.ContainerSelector,
-					MatchLabels:   map[string]string{},
-				}
-
-				for _, resourceFilter := range trap.MatchResources.Any {
-					if resourceFilter.Selector == nil {
-						continue
-					}
-					for key, value := range resourceFilter.Selector.MatchLabels {
-						kiveTrapMatch.MatchLabels[key] = value
-					}
+					MatchLabels:   selectorMatchLabels(resource),
 				}
 
 				kiveTrapMatches = append(kiveTrapMatches, kiveTrapMatch)
@@ -424,4 +406,22 @@ func generateKivePolicy(ctx context.Context, deceptionPolicy *v1alpha1.Deception
 	tracingPolicy.Spec.Traps = kiveTraps
 
 	return tracingPolicy
+}
+
+// selectorMatchLabels returns a copy of the match labels of a resource filter,
+// or an empty map if the resource filter has no selector.
+func selectorMatchLabels(resource v1alpha1.ResourceFilter) map[string]string {
+	matchLabels := map[string]string{}
+	if resource.Selector == nil {
+		return matchLabels
+	}
+	for key, value := range resource.Selector.MatchLabels {
+		matchLabels[key] = value
+	}
+	return matchLabels
+}
+
+// resourceFilterUsesMatchExpressions returns true if a resource filter uses selector.matchExpressions.
+func resourceFilterUsesMatchExpressions(resource v1alpha1.ResourceFilter) bool {
+	return resource.Selector != nil && len(resource.Selector.MatchExpressions) > 0
 }

--- a/internal/controller/traps/filesystoken/utils.go
+++ b/internal/controller/traps/filesystoken/utils.go
@@ -26,6 +26,7 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/client-go/util/retry"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	k8slog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/dynatrace-oss/koney/api/v1alpha1"
 	"github.com/dynatrace-oss/koney/internal/controller/constants"
@@ -226,13 +227,23 @@ func generateTetragonTracingPolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
 		},
 	}
 
-	// Add the labels from the trap's MatchResources to the PodSelector
+	// Add the labels and expressions from the trap's MatchResources to the PodSelector
 	for _, resourceFilter := range trap.MatchResources.Any {
 		if resourceFilter.Selector == nil {
 			continue
 		}
 		for key, value := range resourceFilter.Selector.MatchLabels {
 			tracingPolicy.Spec.PodSelector.MatchLabels[key] = value
+		}
+		for _, requirement := range resourceFilter.Selector.MatchExpressions {
+			tracingPolicy.Spec.PodSelector.MatchExpressions = append(
+				tracingPolicy.Spec.PodSelector.MatchExpressions,
+				slimv1.LabelSelectorRequirement{
+					Key:      requirement.Key,
+					Operator: slimv1.LabelSelectorOperator(requirement.Operator),
+					Values:   requirement.Values,
+				},
+			)
 		}
 	}
 
@@ -315,8 +326,9 @@ func buildKiveWebhookUrl() string {
 }
 
 // generateKivePolicy generates a Kive tracing policy for a filesystem honeytoken trap.
-func generateKivePolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
+func generateKivePolicy(ctx context.Context, deceptionPolicy *v1alpha1.DeceptionPolicy,
 	trap v1alpha1.Trap, tracingPolicyName string) *kivev1.KivePolicy {
+	log := k8slog.FromContext(ctx)
 
 	tracingPolicy := &kivev1.KivePolicy{
 		TypeMeta: metav1.TypeMeta{
@@ -352,6 +364,14 @@ func generateKivePolicy(deceptionPolicy *v1alpha1.DeceptionPolicy,
 		MatchAny: []kivev1.KiveTrapMatch{},
 	}
 	for _, resource := range trap.MatchResources.Any {
+
+		// Kive can only match on plain labels. Generating a match for a selector that also
+		// carries expressions would silently widen the scope of the trap, so we skip it.
+		if resource.Selector != nil && len(resource.Selector.MatchExpressions) > 0 {
+			log.Info("skipping resource filter in Kive policy, because Kive does not support selector.matchExpressions",
+				"policy", deceptionPolicy.Name, "filePath", trap.FilesystemHoneytoken.FilePath)
+			continue
+		}
 
 		kiveTrapMatches := []kivev1.KiveTrapMatch{}
 

--- a/internal/controller/traps/filesystoken/utils_test.go
+++ b/internal/controller/traps/filesystoken/utils_test.go
@@ -241,12 +241,16 @@ var _ = Describe("Policy generation with a trap that uses matchExpressions", fun
 		Expect(kivePolicy.Spec.Traps[0].MatchAny[0].MatchLabels).To(Equal(map[string]string{"app": "frontend"}))
 	})
 
-	It("should warn that the captor does not watch all selected resources", func() {
+	It("should report an error next to the UnsupportedSelectors flag", func() {
 		Expect(trapUsesMatchExpressions(expressionsTrap)).To(BeTrue())
 
-		result := trapsapi.CaptorDeploymentResult{Trap: &expressionsTrap, UnsupportedSelectors: true}
+		result := trapsapi.CaptorDeploymentResult{Trap: &expressionsTrap, Errors: ErrKiveUnsupportedSelectors, UnsupportedSelectors: true}
 		Expect(result.ImpliesSuccess()).To(BeFalse())
 		Expect(result.ImpliesFailure()).To(BeTrue())
+
+		flagOnly := trapsapi.CaptorDeploymentResult{Trap: &expressionsTrap, UnsupportedSelectors: true}
+		Expect(flagOnly.ImpliesSuccess()).To(BeTrue())
+		Expect(flagOnly.ImpliesFailure()).To(BeFalse())
 	})
 })
 
@@ -290,7 +294,7 @@ var _ = Describe("Policy generation with multiple resource filters", func() {
 		Expect(kivePolicy.Spec.Traps[0].MatchAny[1].MatchLabels).To(Equal(map[string]string{"app": "backend", "tier": "db"}))
 	})
 
-	It("should warn that the merged Tetragon podSelector matches fewer pods than the trap selects", func() {
+	It("should leave the Tetragon podSelector empty and warn that it may watch more pods than the trap selects", func() {
 		trapWithTwoExpressions := trapWithTwoFilters
 		trapWithTwoExpressions.MatchResources = v1alpha1.MatchResources{
 			Any: []v1alpha1.ResourceFilter{
@@ -323,9 +327,44 @@ var _ = Describe("Policy generation with multiple resource filters", func() {
 
 		tracingPolicy := generateTetragonTracingPolicy(ctx, &deceptionPolicy, trapWithTwoExpressions, "test-tracing-policy")
 
-		// Both expressions end up in the single podSelector, where they are combined with a logical AND
-		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions).To(HaveLen(2))
-		Expect(messages).To(ContainElement(ContainSubstring("logical AND")))
+		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions).To(BeEmpty())
+		Expect(tracingPolicy.Spec.PodSelector.MatchLabels).To(BeEmpty())
+		Expect(messages).To(ContainElement(ContainSubstring("more pods")))
+	})
+
+	It("should leave the Tetragon podSelector empty when two filters carry labels", func() {
+		tracingPolicy := generateTetragonTracingPolicy(context.Background(), &deceptionPolicy, trapWithTwoFilters, "test-tracing-policy")
+		Expect(tracingPolicy.Spec.PodSelector.MatchLabels).To(BeEmpty())
+		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions).To(BeEmpty())
+	})
+
+	It("should leave the podSelector empty when a labeled filter is mixed with a namespace-only filter", func() {
+		mixedTrap := trapWithTwoFilters
+		mixedTrap.MatchResources = v1alpha1.MatchResources{
+			Any: []v1alpha1.ResourceFilter{
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Selector: &metav1.LabelSelector{MatchLabels: map[string]string{"app": "backend"}},
+					},
+				},
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Namespaces: []string{"ns-a"},
+					},
+				},
+			},
+		}
+
+		messages := []string{}
+		logger := funcr.New(func(prefix, args string) {
+			messages = append(messages, args)
+		}, funcr.Options{})
+		ctx := k8slog.IntoContext(context.Background(), logger)
+
+		tracingPolicy := generateTetragonTracingPolicy(ctx, &deceptionPolicy, mixedTrap, "test-tracing-policy")
+		Expect(tracingPolicy.Spec.PodSelector.MatchLabels).To(BeEmpty())
+		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions).To(BeEmpty())
+		Expect(messages).To(ContainElement(ContainSubstring("more pods")))
 	})
 })
 

--- a/internal/controller/traps/filesystoken/utils_test.go
+++ b/internal/controller/traps/filesystoken/utils_test.go
@@ -20,9 +20,11 @@ import (
 	"encoding/json"
 
 	slimv1 "github.com/cilium/tetragon/pkg/k8s/slim/k8s/apis/meta/v1"
+	"github.com/go-logr/logr/funcr"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	k8slog "sigs.k8s.io/controller-runtime/pkg/log"
 
 	"github.com/dynatrace-oss/koney/api/v1alpha1"
 	"github.com/dynatrace-oss/koney/internal/controller/constants"
@@ -150,6 +152,80 @@ var _ = Describe("DeployCaptor", func() {
 	})
 })
 
+var _ = Describe("Policy generation with a trap that uses matchExpressions", func() {
+	expressionsTrap := v1alpha1.Trap{
+		FilesystemHoneytoken: v1alpha1.FilesystemHoneytoken{
+			FilePath:    "/path/to/file",
+			FileContent: "someverysecrettoken",
+		},
+		MatchResources: v1alpha1.MatchResources{
+			Any: []v1alpha1.ResourceFilter{
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Namespaces: []string{"koney"},
+						Selector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "app",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"backend"},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	deceptionPolicy := v1alpha1.DeceptionPolicy{
+		Spec: v1alpha1.DeceptionPolicySpec{
+			Traps: []v1alpha1.Trap{expressionsTrap},
+		},
+	}
+
+	It("should copy the expressions into the Tetragon PodSelector", func() {
+		tracingPolicy := generateTetragonTracingPolicy(&deceptionPolicy, expressionsTrap, "test-tracing-policy")
+		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions).To(HaveLen(1))
+		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions[0].Key).To(Equal("app"))
+		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions[0].Operator).To(Equal(slimv1.LabelSelectorOpIn))
+		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions[0].Values).To(ConsistOf("backend"))
+	})
+
+	It("should skip the resource filter in the Kive policy and log a warning", func() {
+		messages := []string{}
+		logger := funcr.New(func(prefix, args string) {
+			messages = append(messages, args)
+		}, funcr.Options{})
+		ctx := k8slog.IntoContext(context.Background(), logger)
+
+		kivePolicy := generateKivePolicy(ctx, &deceptionPolicy, expressionsTrap, "test-kive-policy")
+		Expect(kivePolicy.Spec.Traps[0].MatchAny).To(BeEmpty())
+		Expect(messages).To(ContainElement(ContainSubstring("matchExpressions")))
+	})
+
+	It("should keep resource filters that do not use expressions", func() {
+		mixedTrap := expressionsTrap
+		mixedTrap.MatchResources = v1alpha1.MatchResources{
+			Any: append([]v1alpha1.ResourceFilter{
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Namespaces: []string{"other"},
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "frontend"},
+						},
+					},
+				},
+			}, expressionsTrap.MatchResources.Any...),
+		}
+
+		kivePolicy := generateKivePolicy(context.Background(), &deceptionPolicy, mixedTrap, "test-kive-policy")
+		Expect(kivePolicy.Spec.Traps[0].MatchAny).To(HaveLen(1))
+		Expect(kivePolicy.Spec.Traps[0].MatchAny[0].Namespace).To(Equal("other"))
+		Expect(kivePolicy.Spec.Traps[0].MatchAny[0].MatchLabels).To(Equal(map[string]string{"app": "frontend"}))
+	})
+})
+
 var _ = Describe("Policy generation with a namespace-only trap", func() {
 	Context("With a trap that matches resources by namespace and has no label selector", func() {
 		namespaceOnlyTrap := v1alpha1.Trap{
@@ -185,7 +261,7 @@ var _ = Describe("Policy generation with a namespace-only trap", func() {
 					Traps: []v1alpha1.Trap{namespaceOnlyTrap},
 				},
 			}
-			kivePolicy := generateKivePolicy(&deceptionPolicy, namespaceOnlyTrap, "test-kive-policy")
+			kivePolicy := generateKivePolicy(context.Background(), &deceptionPolicy, namespaceOnlyTrap, "test-kive-policy")
 			Expect(kivePolicy.Name).To(Equal("test-kive-policy"))
 			Expect(kivePolicy.Spec.Traps[0].MatchAny).ToNot(BeEmpty())
 			for _, trapMatch := range kivePolicy.Spec.Traps[0].MatchAny {

--- a/internal/controller/traps/filesystoken/utils_test.go
+++ b/internal/controller/traps/filesystoken/utils_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/dynatrace-oss/koney/api/v1alpha1"
 	"github.com/dynatrace-oss/koney/internal/controller/constants"
 	"github.com/dynatrace-oss/koney/internal/controller/matching"
+	trapsapi "github.com/dynatrace-oss/koney/internal/controller/traps/api"
 )
 
 var (
@@ -87,7 +88,7 @@ var _ = Describe("generateTetragonTracingPolicy", func() {
 						Traps: []v1alpha1.Trap{trap},
 					},
 				}
-				tracingPolicy := generateTetragonTracingPolicy(&deceptionPolicy, trap, "test-tracing-policy")
+				tracingPolicy := generateTetragonTracingPolicy(context.Background(), &deceptionPolicy, trap, "test-tracing-policy")
 				Expect(tracingPolicy.Name).To(Equal("test-tracing-policy"))
 
 				// Check the label selector
@@ -185,7 +186,7 @@ var _ = Describe("Policy generation with a trap that uses matchExpressions", fun
 	}
 
 	It("should copy the expressions into the Tetragon PodSelector", func() {
-		tracingPolicy := generateTetragonTracingPolicy(&deceptionPolicy, expressionsTrap, "test-tracing-policy")
+		tracingPolicy := generateTetragonTracingPolicy(context.Background(), &deceptionPolicy, expressionsTrap, "test-tracing-policy")
 		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions).To(HaveLen(1))
 		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions[0].Key).To(Equal("app"))
 		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions[0].Operator).To(Equal(slimv1.LabelSelectorOpIn))
@@ -240,6 +241,13 @@ var _ = Describe("Policy generation with a trap that uses matchExpressions", fun
 		Expect(kivePolicy.Spec.Traps[0].MatchAny[0].MatchLabels).To(Equal(map[string]string{"app": "frontend"}))
 	})
 
+	It("should warn that the captor does not watch all selected resources", func() {
+		Expect(trapUsesMatchExpressions(expressionsTrap)).To(BeTrue())
+
+		result := trapsapi.CaptorDeploymentResult{Trap: &expressionsTrap, UnsupportedSelectors: true}
+		Expect(result.ImpliesSuccess()).To(BeFalse())
+		Expect(result.ImpliesFailure()).To(BeTrue())
+	})
 })
 
 var _ = Describe("Policy generation with multiple resource filters", func() {
@@ -282,6 +290,43 @@ var _ = Describe("Policy generation with multiple resource filters", func() {
 		Expect(kivePolicy.Spec.Traps[0].MatchAny[1].MatchLabels).To(Equal(map[string]string{"app": "backend", "tier": "db"}))
 	})
 
+	It("should warn that the merged Tetragon podSelector matches fewer pods than the trap selects", func() {
+		trapWithTwoExpressions := trapWithTwoFilters
+		trapWithTwoExpressions.MatchResources = v1alpha1.MatchResources{
+			Any: []v1alpha1.ResourceFilter{
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Selector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"prod"}},
+							},
+						},
+					},
+				},
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Selector: &metav1.LabelSelector{
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{Key: "env", Operator: metav1.LabelSelectorOpIn, Values: []string{"dev"}},
+							},
+						},
+					},
+				},
+			},
+		}
+
+		messages := []string{}
+		logger := funcr.New(func(prefix, args string) {
+			messages = append(messages, args)
+		}, funcr.Options{})
+		ctx := k8slog.IntoContext(context.Background(), logger)
+
+		tracingPolicy := generateTetragonTracingPolicy(ctx, &deceptionPolicy, trapWithTwoExpressions, "test-tracing-policy")
+
+		// Both expressions end up in the single podSelector, where they are combined with a logical AND
+		Expect(tracingPolicy.Spec.PodSelector.MatchExpressions).To(HaveLen(2))
+		Expect(messages).To(ContainElement(ContainSubstring("logical AND")))
+	})
 })
 
 var _ = Describe("Policy generation with a namespace-only trap", func() {
@@ -308,7 +353,7 @@ var _ = Describe("Policy generation with a namespace-only trap", func() {
 					Traps: []v1alpha1.Trap{namespaceOnlyTrap},
 				},
 			}
-			tracingPolicy := generateTetragonTracingPolicy(&deceptionPolicy, namespaceOnlyTrap, "test-tracing-policy")
+			tracingPolicy := generateTetragonTracingPolicy(context.Background(), &deceptionPolicy, namespaceOnlyTrap, "test-tracing-policy")
 			Expect(tracingPolicy.Name).To(Equal("test-tracing-policy"))
 			Expect(tracingPolicy.Spec.PodSelector.MatchLabels).To(BeEmpty())
 		})

--- a/internal/controller/traps/filesystoken/utils_test.go
+++ b/internal/controller/traps/filesystoken/utils_test.go
@@ -204,10 +204,10 @@ var _ = Describe("Policy generation with a trap that uses matchExpressions", fun
 		Expect(messages).To(ContainElement(ContainSubstring("matchExpressions")))
 	})
 
-	It("should keep resource filters that do not use expressions", func() {
+	It("should keep resource filters that do not use expressions, without taking over their labels", func() {
 		mixedTrap := expressionsTrap
 		mixedTrap.MatchResources = v1alpha1.MatchResources{
-			Any: append([]v1alpha1.ResourceFilter{
+			Any: []v1alpha1.ResourceFilter{
 				{
 					ResourceDescription: v1alpha1.ResourceDescription{
 						Namespaces: []string{"other"},
@@ -216,7 +216,22 @@ var _ = Describe("Policy generation with a trap that uses matchExpressions", fun
 						},
 					},
 				},
-			}, expressionsTrap.MatchResources.Any...),
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Namespaces: []string{"koney"},
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "backend", "tier": "db"},
+							MatchExpressions: []metav1.LabelSelectorRequirement{
+								{
+									Key:      "env",
+									Operator: metav1.LabelSelectorOpIn,
+									Values:   []string{"prod"},
+								},
+							},
+						},
+					},
+				},
+			},
 		}
 
 		kivePolicy := generateKivePolicy(context.Background(), &deceptionPolicy, mixedTrap, "test-kive-policy")
@@ -224,6 +239,49 @@ var _ = Describe("Policy generation with a trap that uses matchExpressions", fun
 		Expect(kivePolicy.Spec.Traps[0].MatchAny[0].Namespace).To(Equal("other"))
 		Expect(kivePolicy.Spec.Traps[0].MatchAny[0].MatchLabels).To(Equal(map[string]string{"app": "frontend"}))
 	})
+
+})
+
+var _ = Describe("Policy generation with multiple resource filters", func() {
+	deceptionPolicy := v1alpha1.DeceptionPolicy{}
+
+	trapWithTwoFilters := v1alpha1.Trap{
+		FilesystemHoneytoken: v1alpha1.FilesystemHoneytoken{
+			FilePath:    "/path/to/file",
+			FileContent: "someverysecrettoken",
+		},
+		MatchResources: v1alpha1.MatchResources{
+			Any: []v1alpha1.ResourceFilter{
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Namespaces: []string{"ns-a"},
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "frontend"},
+						},
+					},
+				},
+				{
+					ResourceDescription: v1alpha1.ResourceDescription{
+						Namespaces: []string{"ns-b"},
+						Selector: &metav1.LabelSelector{
+							MatchLabels: map[string]string{"app": "backend", "tier": "db"},
+						},
+					},
+				},
+			},
+		},
+	}
+
+	It("should not mix the labels of different resource filters in the Kive policy", func() {
+		kivePolicy := generateKivePolicy(context.Background(), &deceptionPolicy, trapWithTwoFilters, "test-kive-policy")
+
+		Expect(kivePolicy.Spec.Traps[0].MatchAny).To(HaveLen(2))
+		Expect(kivePolicy.Spec.Traps[0].MatchAny[0].Namespace).To(Equal("ns-a"))
+		Expect(kivePolicy.Spec.Traps[0].MatchAny[0].MatchLabels).To(Equal(map[string]string{"app": "frontend"}))
+		Expect(kivePolicy.Spec.Traps[0].MatchAny[1].Namespace).To(Equal("ns-b"))
+		Expect(kivePolicy.Spec.Traps[0].MatchAny[1].MatchLabels).To(Equal(map[string]string{"app": "backend", "tier": "db"}))
+	})
+
 })
 
 var _ = Describe("Policy generation with a namespace-only trap", func() {


### PR DESCRIPTION
closes #68

`matchResources.any[].selector` is a `metav1.LabelSelector` but only `matchLabels` was ever read, so a selector that only uses `matchExpressions` was treated as no selector at all and the trap went to every workload in the namespace

what changed:

- `matching.go` — a selector counts as non-empty when either field is set, and listing goes through `metav1.LabelSelectorAsSelector` so expressions actually narrow the result
- `utils.go` — the Tetragon `PodSelector` now carries the expressions too (converted to the slim type)
- `utils.go` — Kive can't express `matchExpressions` at all (`KiveTrapMatch` only has `matchLabels`), so filters that use them are skipped instead of emitting a labels-only match that would match everything. while fixing that I also had to stop the label loops from walking every filter, they were merging labels across unrelated filters into each match
- `dp_trap_types.go` — `IsValid` no longer treats an expressions-only selector as empty
- a skipped Kive filter now shows up as `CaptorsDeployed=False` with a reason, otherwise you get a healthy looking policy with a trap that nothing watches

tests cover each of those, including that namespaces still narrow an expressions selector, that labels of one filter don't leak into another, and that the merged Tetragon selector warns when more than one filter carries a selector
